### PR TITLE
Activate Camel Language Server for Red hat Fuse stack #64

### DIFF
--- a/ide/codeready-ide-stacks/src/main/resources/stacks.json
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks.json
@@ -397,6 +397,7 @@
                 "org.eclipse.che.exec",
                 "org.eclipse.che.terminal",
                 "org.eclipse.che.ws-agent",
+                "org.eclipse.che.ls.camel",
                 "org.eclipse.che.ls.java",
                 "com.redhat.bayesian.lsp"
               ],


### PR DESCRIPTION
Please add the tests needed. I don't understand what is the policy as the stack is more or less duplicated in 3 repositories (<Eclipse Che, RH Che and this one) with different sets of tests.