### PR TITLE
Selenium: remove info about known issue, check Apache Camel ls initialization

### DIFF
--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaEapUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaEapUserStoryTest.java
@@ -15,7 +15,6 @@ import static com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWor
 import static java.nio.file.Files.readAllLines;
 import static java.nio.file.Paths.get;
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_DEFINITION;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_USAGES;
@@ -151,8 +150,10 @@ public class JavaEapUserStoryTest {
 
     // prepare
     setUpDebugMode();
-    projectExplorer.expandPathInProjectExplorerAndOpenFile(
-        PATH_TO_MAIN_PACKAGE + ".data", "MemberListProducer.java");
+    projectExplorer.quickRevealToItemWithJavaScript(
+        PATH_TO_MAIN_PACKAGE + ".data/MemberListProducer.java");
+    projectExplorer.openItemByVisibleNameInExplorer("MemberListProducer.java");
+    editor.waitActive();
     editor.waitTabIsPresent(fileForDebuggingTabTitle);
     editor.waitTabSelection(0, fileForDebuggingTabTitle);
     editor.waitActive();
@@ -215,7 +216,7 @@ public class JavaEapUserStoryTest {
     }
   }
 
-  @Test(priority = 3, groups = UNDER_REPAIR)
+  @Test(priority = 3)
   public void checkBayesianLsErrorMarker() throws Exception {
     final String pomXmlFilePath = PROJECT + "/pom.xml";
     final String pomXmlEditorTabTitle = "jboss-as-kitchensink";
@@ -235,14 +236,7 @@ public class JavaEapUserStoryTest {
 
     // check error marker displaying and description
     editor.setCursorToLine(62);
-
-    try {
-      editor.waitMarkerInPosition(ERROR_OVERVIEW, 62);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known permanent failure https://issues.jboss.org/browse/CRW-37");
-    }
-
+    editor.waitMarkerInPosition(ERROR_OVERVIEW, 62);
     editor.clickOnMarker(ERROR, 62);
     editor.waitTextInToolTipPopup(expectedErrorMarkerText);
   }
@@ -260,8 +254,8 @@ public class JavaEapUserStoryTest {
   }
 
   private void checkQuickFixFeature(String expectedTextAfterQuickFix) {
-    projectExplorer.expandPathInProjectExplorerAndOpenFile(
-        PATH_TO_MAIN_PACKAGE + ".util", "DecoratorSample.java");
+    projectExplorer.quickRevealToItemWithJavaScript(
+        PATH_TO_MAIN_PACKAGE + ".util/DecoratorSample.java");
     editor.selectTabByName("Member");
     editor.goToPosition(23, 31);
     editor.typeTextIntoEditor(" DecoratorSample,");
@@ -315,8 +309,9 @@ public class JavaEapUserStoryTest {
   }
 
   private void checkGoToDeclarationFeature() {
-    projectExplorer.expandPathInProjectExplorerAndOpenFile(
-        PATH_TO_MAIN_PACKAGE + ".controller", "MemberRegistration.java");
+    projectExplorer.quickRevealToItemWithJavaScript(
+        PATH_TO_MAIN_PACKAGE + ".controller/MemberRegistration.java");
+    projectExplorer.openItemByVisibleNameInExplorer("MemberRegistration.java");
     editor.waitActive();
     editor.goToPosition(39, 14);
     editor.typeTextIntoEditor(F4.toString());
@@ -362,7 +357,7 @@ public class JavaEapUserStoryTest {
     events.waitExpectedMessage("Branch 'master' is checked out");
     consoles.clickOnProcessesButton();
     consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT);
-    projectExplorer.expandPathInProjectExplorer(PATH_TO_MAIN_PACKAGE);
+    projectExplorer.quickRevealToItemWithJavaScript(PATH_TO_MAIN_PACKAGE);
     addTestFileIntoProjectByApi();
 
     return testWorkspace;

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
@@ -15,7 +15,6 @@ import static com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWor
 import static java.nio.file.Files.readAllLines;
 import static java.nio.file.Paths.get;
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_DEFINITION;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_USAGES;
@@ -152,8 +151,10 @@ public class JavaUserStoryTest {
 
     // prepare
     setUpDebugMode();
-    projectExplorer.expandPathInProjectExplorerAndOpenFile(
-        PATH_TO_MAIN_PACKAGE + ".data", "MemberListProducer.java");
+    projectExplorer.quickRevealToItemWithJavaScript(
+        PATH_TO_MAIN_PACKAGE + ".data/MemberListProducer.java");
+    projectExplorer.openItemByVisibleNameInExplorer("MemberListProducer.java");
+    editor.waitActive();
     editor.waitTabIsPresent(fileForDebuggingTabTitle);
     editor.waitTabSelection(0, fileForDebuggingTabTitle);
     editor.waitActive();
@@ -216,7 +217,7 @@ public class JavaUserStoryTest {
     }
   }
 
-  @Test(priority = 3, groups = UNDER_REPAIR)
+  @Test(priority = 3)
   public void checkBayesianLsErrorMarker() throws Exception {
     final String pomXmlFilePath = PROJECT + "/pom.xml";
     final String pomXmlEditorTabTitle = "jboss-as-kitchensink";
@@ -236,14 +237,7 @@ public class JavaUserStoryTest {
 
     // check error marker displaying and description
     editor.setCursorToLine(62);
-
-    try {
-      editor.waitMarkerInPosition(ERROR_OVERVIEW, 62);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known permanent failure https://issues.jboss.org/browse/CRW-37");
-    }
-
+    editor.waitMarkerInPosition(ERROR_OVERVIEW, 62);
     editor.clickOnMarker(ERROR, 62);
     editor.waitTextInToolTipPopup(expectedErrorMarkerText);
   }
@@ -261,8 +255,8 @@ public class JavaUserStoryTest {
   }
 
   private void checkQuickFixFeature(String expectedTextAfterQuickFix) {
-    projectExplorer.expandPathInProjectExplorerAndOpenFile(
-        PATH_TO_MAIN_PACKAGE + ".util", "DecoratorSample.java");
+    projectExplorer.quickRevealToItemWithJavaScript(
+        PATH_TO_MAIN_PACKAGE + ".util/DecoratorSample.java");
     editor.selectTabByName("Member");
     editor.goToPosition(23, 31);
     editor.typeTextIntoEditor(" DecoratorSample,");
@@ -316,8 +310,9 @@ public class JavaUserStoryTest {
   }
 
   private void checkGoToDeclarationFeature() {
-    projectExplorer.expandPathInProjectExplorerAndOpenFile(
-        PATH_TO_MAIN_PACKAGE + ".controller", "MemberRegistration.java");
+    projectExplorer.quickRevealToItemWithJavaScript(
+        PATH_TO_MAIN_PACKAGE + ".controller/MemberRegistration.java");
+    projectExplorer.openItemByVisibleNameInExplorer("MemberRegistration.java");
     editor.waitActive();
     editor.goToPosition(39, 14);
     editor.typeTextIntoEditor(F4.toString());
@@ -363,7 +358,7 @@ public class JavaUserStoryTest {
     events.waitExpectedMessage("Branch 'master' is checked out");
     consoles.clickOnProcessesButton();
     consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT);
-    projectExplorer.expandPathInProjectExplorer(PATH_TO_MAIN_PACKAGE);
+    projectExplorer.quickRevealToItemWithJavaScript(PATH_TO_MAIN_PACKAGE);
     addTestFileIntoProjectByApi();
 
     return testWorkspace;

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/RedHatFuseUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/RedHatFuseUserStoryTest.java
@@ -91,9 +91,10 @@ public class RedHatFuseUserStoryTest {
 
     projectExplorer.waitProjectInitialization(PROJECT_NAME);
 
-    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
-
+    // check Apache Camel language server initialized
     consoles.waitExpectedTextIntoConsole(LS_INIT_MESSAGE);
+
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test(priority = 1)

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/RedHatFuseUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/RedHatFuseUserStoryTest.java
@@ -53,6 +53,8 @@ public class RedHatFuseUserStoryTest {
   private static final String PROJECT_NAME = "spring-boot-camel";
   private static final String PATH_TO_MAIN_PACKAGE =
       PROJECT_NAME + "/src/main/java/io/fabric8/quickstarts/camel";
+  private static final String LS_INIT_MESSAGE =
+      "Initialized language server 'org.eclipse.che.plugin.camel.server.languageserver'";
 
   @Inject private Ide ide;
   @Inject private Menu menu;
@@ -90,6 +92,8 @@ public class RedHatFuseUserStoryTest {
     projectExplorer.waitProjectInitialization(PROJECT_NAME);
 
     consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
+
+    consoles.waitExpectedTextIntoConsole(LS_INIT_MESSAGE);
   }
 
   @Test(priority = 1)


### PR DESCRIPTION
This PR:
- add checking ```Apache Camel``` language server initialization in ```Red Hat Fuse``` stack;
- remove info about known https://issues.jboss.org/browse/CRW-37 issue from **JavaUserStoryTest** and **JavaEapUserStoryTest** tests.