### PR TITLE
Tets E2E: Add the missed annotations '@Override' to selenium tests

### DIFF
--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyStepIntoStepOverStepReturnWithChangeVariableTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyStepIntoStepOverStepReturnWithChangeVariableTest.java
@@ -49,6 +49,7 @@ public class CodeReadyStepIntoStepOverStepReturnWithChangeVariableTest
     consoles.closeProcessTabWithAskDialog(START_DEBUG);
   }
 
+  @Override
   protected void waitExpectedTextIntoConsole() {
     consoles.waitExpectedTextIntoConsole("started in");
   }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/CodeReadySplitEditorFeatureTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/CodeReadySplitEditorFeatureTest.java
@@ -16,6 +16,7 @@ import org.eclipse.che.selenium.editor.SplitEditorFeatureTest;
 /** @author Aleksandr Shmaraiev */
 public class CodeReadySplitEditorFeatureTest extends SplitEditorFeatureTest {
 
+  @Override
   protected String getJavaFileNameFromTabTitle() {
     return "MemberRegistration";
   }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/autocomplete/CodeReadyAutocompleteProposalJavaDocTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/autocomplete/CodeReadyAutocompleteProposalJavaDocTest.java
@@ -15,6 +15,7 @@ import org.eclipse.che.selenium.editor.autocomplete.AutocompleteProposalJavaDocT
 
 public class CodeReadyAutocompleteProposalJavaDocTest extends AutocompleteProposalJavaDocTest {
 
+  @Override
   protected String getExpectedJavadocHtmlText() {
     return "<p>Returns concatination of two strings into one divided by special symbol.</p>\n"
         + "<ul>\n"

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyAutocompleteCommandsEditorTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyAutocompleteCommandsEditorTest.java
@@ -36,6 +36,7 @@ public class CodeReadyAutocompleteCommandsEditorTest extends AutocompleteCommand
     commandsEditor.waitTextIntoDescriptionMacrosForm("Returns address of the eap server");
   }
 
+  @Override
   protected void launchAutocompleteAndWaitText() {
     commandsEditor.typeTextIntoEditor("server.eap-d");
     commandsEditor.launchAutocomplete();

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyCheckIntelligenceCommandFromToolbarTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyCheckIntelligenceCommandFromToolbarTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 public class CodeReadyCheckIntelligenceCommandFromToolbarTest
     extends CheckIntelligenceCommandFromToolbarTest {
 
+  @Override
   @Test(priority = 1)
   public void checkButtonsOnToolbarOnOpenshift() {
     checkButtonsOnToolbar("Application is not available");


### PR DESCRIPTION
* Add the missed annotations _@Override_ to the selenium tests 