### PR TITLE
Introduce nightly profile

### DIFF
--- a/ide/codeready-ide-stacks/pom.xml
+++ b/ide/codeready-ide-stacks/pom.xml
@@ -19,4 +19,47 @@
     </parent>
     <artifactId>codeready-stacks</artifactId>
     <name>CodeReady Stacks :: IDE :: STACKS</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>update-image-links</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target if="${nightly}">
+                                <echo message="Using images from quay.io"/>
+                                <replace
+                                        token="registry.access.redhat.com/codeready-workspaces"
+                                        file="${project.basedir}/src/main/resources/stacks.json"
+                                        value="quay.io/crw"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>revert</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target if="${nightly}">
+                                <echo message="Restoring stacks.json"/>
+                                <replace token="quay.io/crw"
+                                         file="${project.basedir}/src/main/resources/stacks.json"
+                                         value="registry.access.redhat.com/codeready-workspaces"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/ide/codeready-ide-stacks/src/main/resources/stacks.json
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks.json
@@ -64,7 +64,7 @@
             }
           },
           "recipe": {
-            "content": "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/codeready-workspaces/stacks-java",
+            "content": "registry.access.redhat.com/codeready-workspaces/stacks-java",
             "type": "dockerimage"
           }
         }
@@ -148,7 +148,7 @@
             }
           },
           "recipe": {
-            "content": "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/codeready-workspaces/stacks-java",
+            "content": "registry.access.redhat.com/codeready-workspaces/stacks-java",
             "type": "dockerimage"
           }
         }
@@ -254,7 +254,7 @@
             }
           },
           "recipe": {
-            "content": "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/codeready-workspaces/stacks-java",
+            "content": "registry.access.redhat.com/codeready-workspaces/stacks-java",
             "type": "dockerimage"
           }
         }
@@ -340,7 +340,7 @@
             }
           },
           "recipe": {
-            "content": "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/codeready-workspaces/stacks-java",
+            "content": "registry.access.redhat.com/codeready-workspaces/stacks-java",
             "type": "dockerimage"
           }
         }
@@ -421,7 +421,7 @@
             }
           },
           "recipe": {
-            "content": "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/codeready-workspaces/stacks-java",
+            "content": "registry.access.redhat.com/codeready-workspaces/stacks-java",
             "type": "dockerimage"
           }
         }
@@ -503,7 +503,7 @@
             }
           },
           "recipe": {
-            "content": "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/codeready-workspaces/stacks-java",
+            "content": "registry.access.redhat.com/codeready-workspaces/stacks-java",
             "type": "dockerimage"
           }
         }
@@ -583,7 +583,7 @@
             }
           },
           "recipe": {
-            "content": "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/codeready-workspaces/stacks-cpp",
+            "content": "registry.access.redhat.com/codeready-workspaces/stacks-cpp",
             "type": "dockerimage"
           }
         }
@@ -651,7 +651,7 @@
             }
           },
           "recipe": {
-            "content": "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/codeready-workspaces/stacks-dotnet",
+            "content": "registry.access.redhat.com/codeready-workspaces/stacks-dotnet",
             "type": "dockerimage"
           }
         }
@@ -722,7 +722,7 @@
             }
           },
           "recipe": {
-            "content": "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/codeready-workspaces/stacks-golang",
+            "content": "registry.access.redhat.com/codeready-workspaces/stacks-golang",
             "type": "dockerimage"
           }
         }
@@ -804,7 +804,7 @@
             }
           },
           "recipe": {
-            "content": "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/codeready-workspaces/stacks-node",
+            "content": "registry.access.redhat.com/codeready-workspaces/stacks-node",
             "type": "dockerimage"
           }
         }
@@ -870,7 +870,7 @@
             }
           },
           "recipe": {
-            "content": "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/codeready-workspaces/stacks-php",
+            "content": "registry.access.redhat.com/codeready-workspaces/stacks-php",
             "type": "dockerimage"
           }
         }
@@ -983,7 +983,7 @@
             }
           },
           "recipe": {
-            "content": "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/codeready-workspaces/stacks-python",
+            "content": "registry.access.redhat.com/codeready-workspaces/stacks-python",
             "type": "dockerimage"
           }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <che.version>6.17.0-SNAPSHOT</che.version>
         <che.dashboard.version>6.17.0-SNAPSHOT</che.dashboard.version>
+        <nightly>false</nightly>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -176,4 +177,12 @@
         <module>assembly</module>
         <module>test</module>
     </modules>
+    <profiles>
+        <profile>
+            <id>nightly</id>
+            <properties>
+                <nightly>true</nightly>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
### What does this PR do

This PR:

* introduces nightly profile to codeready-workspaces assembly. The profile makes Che server use images from quay.io which will be updated daily (or nightly)
* sets images in stacks.json to be coming from RHCC (they do not exist yet)

### How to activate profile

```
mvn clean install -Pnightly
```

It is also possible to set property on the command line:

```
mvn clean install -Dnightly=true
```

The profile is declared in the root pom, so if you want to build `ide/codeready-ide-stacks` module individually, make sure you set a property, rather than use a profile.

