### PR TITLE
Test E2E: Change timeout in the selenium tests

### DIFF
--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/DotNetUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/DotNetUserStoryTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.che.selenium.core.constant.TestIntelligentCommandsCons
 import static org.eclipse.che.selenium.core.constant.TestIntelligentCommandsConstants.CommandItem.UPDATE_DEPENDENCIES_COMMAND_ITEM;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.BUILD_GOAL;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.RUN_GOAL;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.INFO;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.DOT_NET;
@@ -135,7 +136,7 @@ public class DotNetUserStoryTest {
   }
 
   public void checkCodeValidation() {
-    editor.waitAllMarkersInvisibility(ERROR);
+    editor.waitAllMarkersInvisibility(ERROR, LOADER_TIMEOUT_SEC);
     editor.goToPosition(24, 12);
     editor.typeTextIntoEditor(Keys.BACK_SPACE.toString());
     editor.waitMarkerInPosition(ERROR, 24);
@@ -153,7 +154,8 @@ public class DotNetUserStoryTest {
     editor.launchAutocomplete();
     editor.enterAutocompleteProposal("Build ");
     editor.typeTextIntoEditor("();");
-    editor.waitAllMarkersInvisibility(ERROR);
+    editor.waitTextIntoEditor("Build();");
+    editor.waitAllMarkersInvisibility(ERROR, LOADER_TIMEOUT_SEC);
   }
 
   private void initLanguageServer() {

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaEapUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaEapUserStoryTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.A
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_USAGES;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.QUICK_DOCUMENTATION;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.QUICK_FIX;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.utils.FileUtil.readFileToString;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR_OVERVIEW;
@@ -278,7 +279,7 @@ public class JavaEapUserStoryTest {
     editor.goToPosition(28, 18);
     menu.runCommand(ASSISTANT, QUICK_FIX);
     editor.enterTextIntoFixErrorPropByDoubleClick("Change to 'Logger' (java.util.logging)");
-    editor.waitAllMarkersInvisibility(ERROR_OVERVIEW);
+    editor.waitAllMarkersInvisibility(ERROR_OVERVIEW, LOADER_TIMEOUT_SEC);
   }
 
   private void checkQuickDocumentationFeature(

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.A
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_USAGES;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.QUICK_DOCUMENTATION;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.QUICK_FIX;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.utils.FileUtil.readFileToString;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR_OVERVIEW;
@@ -279,7 +280,7 @@ public class JavaUserStoryTest {
     editor.goToPosition(28, 18);
     menu.runCommand(ASSISTANT, QUICK_FIX);
     editor.enterTextIntoFixErrorPropByDoubleClick("Change to 'Logger' (java.util.logging)");
-    editor.waitAllMarkersInvisibility(ERROR_OVERVIEW);
+    editor.waitAllMarkersInvisibility(ERROR_OVERVIEW, LOADER_TIMEOUT_SEC);
   }
 
   private void checkQuickDocumentationFeature(


### PR DESCRIPTION
* Change the timeout in the selenium tests to increase reliability when run on CI
* Related selenium tests:  _DotNetUserStoryTest_, _JavaEapUserStoryTest_, _JavaUserStoryTest_
* Depends on the https://github.com/eclipse/che/pull/12402