### PR TITLE
Fix tag for RHEL8 image

### DIFF
--- a/ide/codeready-ide-stacks/src/main/resources/stacks.json
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks.json
@@ -55,7 +55,7 @@
             }
           },
           "recipe": {
-            "content": "registry.access.redhat.com/codeready-workspaces/stacks-java-rhel8:1.0.0",
+            "content": "registry.access.redhat.com/codeready-workspaces/stacks-java-rhel8",
             "type": "dockerimage"
           }
         }


### PR DESCRIPTION
1.0.0 does not exist in quay.io

I have created such a tag to unblock everyone.