### PR TITLE
Move to 6.18.0-SNAPSHOT

### DIFF
--- a/assembly/assembly-dashboard-war/pom.xml
+++ b/assembly/assembly-dashboard-war/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>codeready-dashboard-war</artifactId>
     <packaging>pom</packaging>

--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>codeready-ide-assembly-ide-war</artifactId>
     <packaging>war</packaging>

--- a/assembly/assembly-wsagent-server/pom.xml
+++ b/assembly/assembly-wsagent-server/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>codeready-workspaces-assembly-wsagent-server</artifactId>
     <packaging>pom</packaging>

--- a/assembly/assembly-wsagent-war/pom.xml
+++ b/assembly/assembly-wsagent-war/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>codeready-workspaces-assembly-wsagent-war</artifactId>
     <packaging>war</packaging>

--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>assembly-wsmaster-war</artifactId>
     <packaging>war</packaging>

--- a/assembly/codeready-ide-gwt-app/pom.xml
+++ b/assembly/codeready-ide-gwt-app/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>codeready-ide-gwt-app</artifactId>
     <packaging>gwt-app</packaging>

--- a/assembly/codeready-workspaces-assembly-main/pom.xml
+++ b/assembly/codeready-workspaces-assembly-main/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>codeready-workspaces-assembly-main</artifactId>
     <packaging>pom</packaging>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>codeready</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <groupId>com.redhat</groupId>
     <artifactId>codeready-assembly-parent</artifactId>

--- a/ide/codeready-ide-samples/pom.xml
+++ b/ide/codeready-ide-samples/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>codeready-ide-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>codeready-samples</artifactId>
     <name>CodeReady Samples :: IDE :: SAMPLES</name>

--- a/ide/codeready-ide-stacks/pom.xml
+++ b/ide/codeready-ide-stacks/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>codeready-ide-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>codeready-stacks</artifactId>
     <name>CodeReady Stacks :: IDE :: STACKS</name>

--- a/ide/codeready-product-info/pom.xml
+++ b/ide/codeready-product-info/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-ide-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>codeready-product-info</artifactId>
     <packaging>gwt-lib</packaging>

--- a/ide/pom.xml
+++ b/ide/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>codeready</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>codeready-ide-parent</artifactId>

--- a/plugins/che-plugin-bayesian-lang-server/pom.xml
+++ b/plugins/che-plugin-bayesian-lang-server/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-plugins-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>che-plugin-bayesian-lang-server</artifactId>
     <packaging>jar</packaging>

--- a/plugins/ls-bayesian-agent/pom.xml
+++ b/plugins/ls-bayesian-agent/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>codeready</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>ls-bayesian-agent</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>codeready</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>codeready-plugins-parent</artifactId>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,11 @@
     <parent>
         <artifactId>maven-depmgt-pom</artifactId>
         <groupId>org.eclipse.che.depmgt</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <groupId>com.redhat</groupId>
     <artifactId>codeready</artifactId>
-    <version>6.17.0-SNAPSHOT</version>
+    <version>6.18.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>CodeReady :: Parent</name>
     <!--replace with CodeReady product page-->
@@ -31,8 +31,8 @@
         </license>
     </licenses>
     <properties>
-        <che.version>6.17.0-SNAPSHOT</che.version>
-        <che.dashboard.version>6.17.0-SNAPSHOT</che.dashboard.version>
+        <che.version>6.18.0-SNAPSHOT</che.version>
+        <che.dashboard.version>6.18.0-SNAPSHOT</che.dashboard.version>
         <nightly>false</nightly>
     </properties>
     <dependencyManagement>

--- a/test/codeready-test-e2e/pom.xml
+++ b/test/codeready-test-e2e/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-test-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>codeready-test-e2e</artifactId>
     <packaging>jar</packaging>

--- a/test/codeready-test-performance/pom.xml
+++ b/test/codeready-test-performance/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-test-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <artifactId>codeready-test-performance</artifactId>
     <packaging>jar</packaging>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.17.0-SNAPSHOT</version>
+        <version>6.18.0-SNAPSHOT</version>
     </parent>
     <groupId>com.redhat</groupId>
     <artifactId>codeready-test-parent</artifactId>


### PR DESCRIPTION
Eclipse Che 6.17.0 has being released.
This request moves master branch to next version which is compatible with Eclipse Che 6.18.0-SNAPSHOT