### PR TITLE
Fix rhel8 image tag

### DIFF
--- a/ide/codeready-ide-stacks/pom.xml
+++ b/ide/codeready-ide-stacks/pom.xml
@@ -37,6 +37,10 @@
                             <target if="${nightly}">
                                 <echo message="Using images from quay.io"/>
                                 <replace
+                                        token="registry.access.redhat.com/codeready-workspaces-beta"
+                                        file="${project.basedir}/src/main/resources/stacks.json"
+                                        value="quay.io/crw"/>
+                                <replace
                                         token="registry.access.redhat.com/codeready-workspaces"
                                         file="${project.basedir}/src/main/resources/stacks.json"
                                         value="quay.io/crw"/>
@@ -52,6 +56,9 @@
                         <configuration>
                             <target if="${nightly}">
                                 <echo message="Restoring stacks.json"/>
+                                <replace token="quay.io/crw/stacks-java-rhel8"
+                                         file="${project.basedir}/src/main/resources/stacks.json"
+                                         value="registry.access.redhat.com/codeready-workspaces-beta/stacks-java-rhel8"/>
                                 <replace token="quay.io/crw"
                                          file="${project.basedir}/src/main/resources/stacks.json"
                                          value="registry.access.redhat.com/codeready-workspaces"/>

--- a/ide/codeready-ide-stacks/src/main/resources/stacks.json
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks.json
@@ -55,7 +55,7 @@
             }
           },
           "recipe": {
-            "content": "registry.access.redhat.com/codeready-workspaces/stacks-java-rhel8",
+            "content": "registry.access.redhat.com/codeready-workspaces-beta/stacks-java-rhel8",
             "type": "dockerimage"
           }
         }

--- a/ide/codeready-ide-stacks/src/main/resources/stacks.json
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks.json
@@ -55,7 +55,7 @@
             }
           },
           "recipe": {
-            "content": "registry.access.redhat.com/codeready-workspaces/stacks-java-rhel8:1.0.0",
+            "content": "registry.access.redhat.com/codeready-workspaces/stacks-java-rhel8",
             "type": "dockerimage"
           }
         }


### PR DESCRIPTION
It turns our RHEL 8 images will be available in RHCC at registry.access.redhat.com/codeready-workspaces-beta/stacks-java-rhel8