### PR TITLE
Fix e2e tests to use new address of kitchensink

### DIFF
--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/AddOrImportProjectFormTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/AddOrImportProjectFormTest.java
@@ -46,10 +46,10 @@ public class AddOrImportProjectFormTest {
   private static final String NAME_WITH_SPECIAL_CHARACTERS = "@#$%^&*";
   private static final String KITCHENSINCK_EXAMPLE = "kitchensink-example";
   private static final String EXPECTED_KITCHENSINC_REPOSITORY_URL =
-      "https://github.com/openshift-quickstart/kitchensink-example.git";
+      "https://github.com/che-samples/kitchensink-example.git";
   private static final String RENAMED_KITCHENSINK_SAMPLE_NAME = "kitchensink";
   private static final String EXPECTED_CONSOLE_REPOSITORY_URL =
-      "https://github.com/openshift-quickstart/kitchensink-example.git";
+      "https://github.com/che-samples/kitchensink-example.git";
   private static final String BLANK_FORM_DESCRIPTION = "example of description";
   private static final String CUSTOM_BLANK_PROJECT_NAME = "blank-project";
   private static final String BLANK_PROJECT_NAME = "blank";


### PR DESCRIPTION
It fixes on address **kitchensink-example** in E2E tests:
```
https://github.com/openshift-quickstart/kitchensink-example.git
>
https://github.com/che-samples/kitchensink-example.git
```

Test report could be find [here](https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/CRW-1.0.0-GA-tests/job/6.17.x-daily-e2e-tests/12/E2E_20tests_20report/).

Related issue: https://issues.jboss.org/browse/CRW-89

Signed-off-by: Dmytro Nochevnov <dnochevn@redhat.com>