### PR TITLE
CRW-136 attempt to use 1.0.1 version for CRW...

### DIFF
--- a/assembly/assembly-dashboard-war/pom.xml
+++ b/assembly/assembly-dashboard-war/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-dashboard-war</artifactId>
     <packaging>pom</packaging>

--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-ide-assembly-ide-war</artifactId>
     <packaging>war</packaging>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.redhat</groupId>
             <artifactId>codeready-ide-gwt-app</artifactId>
-            <version>${project.version}</version>
+            <version>1.0.1.GA</version>
             <type>war</type>
         </dependency>
         <dependency>

--- a/assembly/assembly-wsagent-server/pom.xml
+++ b/assembly/assembly-wsagent-server/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-workspaces-assembly-wsagent-server</artifactId>
     <packaging>pom</packaging>
@@ -27,6 +27,7 @@
         <dependency>
             <groupId>com.redhat</groupId>
             <artifactId>codeready-workspaces-assembly-wsagent-war</artifactId>
+            <version>1.0.1.GA</version>
             <type>war</type>
         </dependency>
     </dependencies>

--- a/assembly/assembly-wsagent-war/pom.xml
+++ b/assembly/assembly-wsagent-war/pom.xml
@@ -18,19 +18,22 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-workspaces-assembly-wsagent-war</artifactId>
+    <version>1.0.1.GA</version>
     <packaging>war</packaging>
     <name>CodeReady Workspaces :: Workspace Agent</name>
     <dependencies>
         <dependency>
             <groupId>com.redhat</groupId>
             <artifactId>che-plugin-bayesian-lang-server</artifactId>
+            <version>1.0.1.GA</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che</groupId>
             <artifactId>assembly-wsagent-war</artifactId>
+            <version>${che.version}</version>
             <type>war</type>
         </dependency>
     </dependencies>

--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>assembly-wsmaster-war</artifactId>
     <packaging>war</packaging>
@@ -29,19 +29,23 @@
         <dependency>
             <groupId>com.redhat</groupId>
             <artifactId>ls-bayesian-agent</artifactId>
+            <version>1.0.1.GA</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che</groupId>
             <artifactId>assembly-wsmaster-war</artifactId>
+            <version>${che.version}</version>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>com.redhat</groupId>
             <artifactId>codeready-stacks</artifactId>
+            <version>1.0.1.GA</version>
         </dependency>
         <dependency>
             <groupId>com.redhat</groupId>
             <artifactId>codeready-samples</artifactId>
+            <version>1.0.1.GA</version>
         </dependency>
     </dependencies>
     <build>

--- a/assembly/codeready-ide-gwt-app/pom.xml
+++ b/assembly/codeready-ide-gwt-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-ide-gwt-app</artifactId>
     <packaging>gwt-app</packaging>
@@ -35,11 +35,13 @@
         <dependency>
             <groupId>com.redhat</groupId>
             <artifactId>codeready-product-info</artifactId>
+            <version>1.0.1.GA</version>
             <type>gwt-lib</type>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-ide-full</artifactId>
+            <version>${che.version}</version>
             <type>gwt-lib</type>
             <exclusions>
                 <exclusion>

--- a/assembly/codeready-workspaces-assembly-main/pom.xml
+++ b/assembly/codeready-workspaces-assembly-main/pom.xml
@@ -19,11 +19,12 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-workspaces-assembly-main</artifactId>
     <packaging>pom</packaging>
     <name>CodeReady Workspaces :: Tomcat Assembly</name>
+    <version>1.0.1.GA</version>
 
     <properties>
         <jbossNexus>repository.jboss.org</jbossNexus>
@@ -94,6 +95,7 @@
                                 <artifactItem>
                                     <groupId>org.eclipse.che</groupId>
                                     <artifactId>assembly-main</artifactId>
+                                    <version>6.19.0-SNAPSHOT</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/dependency</outputDirectory>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <groupId>com.redhat</groupId>
     <artifactId>codeready-assembly-parent</artifactId>

--- a/ide/codeready-ide-samples/pom.xml
+++ b/ide/codeready-ide-samples/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>codeready-ide-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-samples</artifactId>
     <name>CodeReady Samples :: IDE :: SAMPLES</name>

--- a/ide/codeready-ide-stacks/pom.xml
+++ b/ide/codeready-ide-stacks/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>codeready-ide-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-stacks</artifactId>
     <name>CodeReady Stacks :: IDE :: STACKS</name>

--- a/ide/codeready-product-info/pom.xml
+++ b/ide/codeready-product-info/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-ide-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-product-info</artifactId>
     <packaging>gwt-lib</packaging>
@@ -38,6 +38,7 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-ide-api</artifactId>
+            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.vectomatic</groupId>

--- a/ide/pom.xml
+++ b/ide/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>codeready</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-ide-parent</artifactId>
     <packaging>pom</packaging>

--- a/plugins/che-plugin-bayesian-lang-server/pom.xml
+++ b/plugins/che-plugin-bayesian-lang-server/pom.xml
@@ -18,9 +18,10 @@
     <parent>
         <artifactId>codeready-plugins-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>che-plugin-bayesian-lang-server</artifactId>
+    <version>1.0.1.GA</version>
     <packaging>jar</packaging>
     <name>CodeReady Workspaces: Plugins :: Bayesian LSP Integration</name>
     <dependencies>
@@ -31,18 +32,22 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-languageserver</artifactId>
+            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-languageserver-shared</artifactId>
+            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-inject</artifactId>
+            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-json-server</artifactId>
+            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.lsp4j</groupId>

--- a/plugins/ls-bayesian-agent/pom.xml
+++ b/plugins/ls-bayesian-agent/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-plugins-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>ls-bayesian-agent</artifactId>
     <name>CodeReady Workspaces :: Plugins :: Bayesian LSP Agent</name>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>codeready</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-plugins-parent</artifactId>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <groupId>com.redhat</groupId>
     <artifactId>codeready</artifactId>
-    <version>6.19.0-SNAPSHOT</version>
+    <version>1.0.1.GA</version>
     <packaging>pom</packaging>
     <name>CodeReady :: Parent</name>
     <url>https://developers.redhat.com/products/codeready-workspaces/overview/</url>
@@ -35,8 +35,8 @@
         </license>
     </licenses>
     <properties>
-        <che.version>${project.parent.version}</che.version>
-        <che.dashboard.version>${project.parent.version}</che.dashboard.version>
+        <che.version>6.19.0-SNAPSHOT</che.version>
+        <che.dashboard.version>${che.version}</che.dashboard.version>
         <nightly>false</nightly>
     </properties>
     <dependencyManagement>
@@ -44,54 +44,54 @@
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-ide-gwt-app</artifactId>
-                <version>${project.version}</version>
+                <version>1.0.1.GA</version>
                 <type>war</type>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-product-info</artifactId>
-                <version>${project.version}</version>
+                <version>1.0.1.GA</version>
                 <type>gwt-lib</type>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-dashboard-war</artifactId>
                 <type>war</type>
-                <version>${project.version}</version>
+                <version>1.0.1.GA</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-ide-assembly-ide-war</artifactId>
                 <type>war</type>
-                <version>${project.version}</version>
+                <version>1.0.1.GA</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-stacks</artifactId>
-                <version>${project.version}</version>
+                <version>1.0.1.GA</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-samples</artifactId>
-                <version>${project.version}</version>
+                <version>1.0.1.GA</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>assembly-main</artifactId>
                 <type>tar.gz</type>
-                <version>${project.version}</version>
+                <version>1.0.1.GA</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>assembly-main</artifactId>
                 <type>zip</type>
-                <version>${project.version}</version>
+                <version>1.0.1.GA</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>assembly-wsmaster-war</artifactId>
                 <type>war</type>
-                <version>${project.version}</version>
+                <version>1.0.1.GA</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
@@ -103,7 +103,7 @@
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>che-plugin-bayesian-lang-server</artifactId>
-                <version>${project.version}</version>
+                <version>1.0.1.GA</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
@@ -114,23 +114,23 @@
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-workspaces-assembly-wsagent-server</artifactId>
-                <version>${project.version}</version>
+                <version>1.0.1.GA</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-workspaces-assembly-wsagent-war</artifactId>
-                <version>${project.version}</version>
+                <version>1.0.1.GA</version>
                 <type>war</type>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>ls-bayesian-agent</artifactId>
-                <version>${project.version}</version>
+                <version>1.0.1.GA</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-workspaces-assembly-wsagent-server</artifactId>
-                <version>${project.version}</version>
+                <version>1.0.1.GA</version>
                 <type>tar.gz</type>
             </dependency>
         </dependencies>

--- a/test/codeready-test-e2e/pom.xml
+++ b/test/codeready-test-e2e/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-test-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-test-e2e</artifactId>
     <packaging>jar</packaging>

--- a/test/codeready-test-performance/pom.xml
+++ b/test/codeready-test-performance/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-test-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-test-performance</artifactId>
     <packaging>jar</packaging>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>1.0.1.GA</version>
     </parent>
     <groupId>com.redhat</groupId>
     <artifactId>codeready-test-parent</artifactId>


### PR DESCRIPTION
CRW-136 attempt to use 1.0.1 version for CRW while still depending on Che 6.19.0-SNAPSHOT

Change-Id: If18df646ed14fc9a7605a1a5d989c91b3c5260b7
Signed-off-by: nickboldt <nboldt@redhat.com>