### PR TITLE
CRW-136 use 1.0.1 version for CRW while still depending on Che 6.18

### DIFF
--- a/assembly/assembly-dashboard-war/pom.xml
+++ b/assembly/assembly-dashboard-war/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-dashboard-war</artifactId>
     <packaging>pom</packaging>

--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-ide-assembly-ide-war</artifactId>
     <packaging>war</packaging>
@@ -31,13 +31,11 @@
         <dependency>
             <groupId>com.redhat</groupId>
             <artifactId>codeready-ide-gwt-app</artifactId>
-            <version>${project.version}</version>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che</groupId>
             <artifactId>assembly-ide-war</artifactId>
-            <version>${che.version}</version>
             <type>war</type>
             <scope>runtime</scope>
         </dependency>

--- a/assembly/assembly-wsagent-server/pom.xml
+++ b/assembly/assembly-wsagent-server/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-workspaces-assembly-wsagent-server</artifactId>
     <packaging>pom</packaging>

--- a/assembly/assembly-wsagent-war/pom.xml
+++ b/assembly/assembly-wsagent-war/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-workspaces-assembly-wsagent-war</artifactId>
     <packaging>war</packaging>

--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>assembly-wsmaster-war</artifactId>
     <packaging>war</packaging>

--- a/assembly/codeready-ide-gwt-app/pom.xml
+++ b/assembly/codeready-ide-gwt-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-ide-gwt-app</artifactId>
     <packaging>gwt-app</packaging>

--- a/assembly/codeready-workspaces-assembly-main/pom.xml
+++ b/assembly/codeready-workspaces-assembly-main/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>codeready-assembly-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-workspaces-assembly-main</artifactId>
     <packaging>pom</packaging>
@@ -94,6 +94,7 @@
                                 <artifactItem>
                                     <groupId>org.eclipse.che</groupId>
                                     <artifactId>assembly-main</artifactId>
+                                    <version>${che.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/dependency</outputDirectory>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <groupId>com.redhat</groupId>
     <artifactId>codeready-assembly-parent</artifactId>

--- a/ide/codeready-ide-samples/pom.xml
+++ b/ide/codeready-ide-samples/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>codeready-ide-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-samples</artifactId>
     <name>CodeReady Samples :: IDE :: SAMPLES</name>

--- a/ide/codeready-ide-stacks/pom.xml
+++ b/ide/codeready-ide-stacks/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>codeready-ide-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-stacks</artifactId>
     <name>CodeReady Stacks :: IDE :: STACKS</name>

--- a/ide/codeready-product-info/pom.xml
+++ b/ide/codeready-product-info/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-ide-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-product-info</artifactId>
     <packaging>gwt-lib</packaging>

--- a/ide/pom.xml
+++ b/ide/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>codeready</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-ide-parent</artifactId>
     <packaging>pom</packaging>

--- a/plugins/che-plugin-bayesian-lang-server/pom.xml
+++ b/plugins/che-plugin-bayesian-lang-server/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>codeready-plugins-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>che-plugin-bayesian-lang-server</artifactId>
     <packaging>jar</packaging>

--- a/plugins/ls-bayesian-agent/pom.xml
+++ b/plugins/ls-bayesian-agent/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-plugins-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>ls-bayesian-agent</artifactId>
     <name>CodeReady Workspaces :: Plugins :: Bayesian LSP Agent</name>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>codeready</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-plugins-parent</artifactId>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <groupId>com.redhat</groupId>
     <artifactId>codeready</artifactId>
-    <version>6.18.0</version>
+    <version>1.0.1.GA</version>
     <packaging>pom</packaging>
     <name>CodeReady :: Parent</name>
     <url>https://developers.redhat.com/products/codeready-workspaces/overview/</url>
@@ -35,8 +35,9 @@
         </license>
     </licenses>
     <properties>
-        <che.version>${project.parent.version}</che.version>
-        <che.dashboard.version>${project.parent.version}</che.dashboard.version>
+        <che.version>6.18.0</che.version>
+        <che.dashboard.version>${che.version}</che.dashboard.version>
+        <crw.version>1.0.1.GA</crw.version>
         <nightly>false</nightly>
     </properties>
     <dependencyManagement>
@@ -44,54 +45,54 @@
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-ide-gwt-app</artifactId>
-                <version>${project.version}</version>
+                <version>${crw.version}</version>
                 <type>war</type>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-product-info</artifactId>
-                <version>${project.version}</version>
+                <version>${crw.version}</version>
                 <type>gwt-lib</type>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-dashboard-war</artifactId>
                 <type>war</type>
-                <version>${project.version}</version>
+                <version>${crw.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-ide-assembly-ide-war</artifactId>
                 <type>war</type>
-                <version>${project.version}</version>
+                <version>${crw.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-stacks</artifactId>
-                <version>${project.version}</version>
+                <version>${crw.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-samples</artifactId>
-                <version>${project.version}</version>
+                <version>${crw.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>assembly-main</artifactId>
                 <type>tar.gz</type>
-                <version>${project.version}</version>
+                <version>${crw.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>assembly-main</artifactId>
                 <type>zip</type>
-                <version>${project.version}</version>
+                <version>${crw.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>assembly-wsmaster-war</artifactId>
                 <type>war</type>
-                <version>${project.version}</version>
+                <version>${crw.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
@@ -101,9 +102,14 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-ide-api</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>che-plugin-bayesian-lang-server</artifactId>
-                <version>${project.version}</version>
+                <version>${crw.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che</groupId>
@@ -112,25 +118,51 @@
                 <type>war</type>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-ide-full</artifactId>
+                <version>${che.version}</version>
+                <type>gwt-lib</type>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-languageserver</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-languageserver-shared</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-commons-inject</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.plugin</groupId>
+                <artifactId>che-plugin-json-server</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-workspaces-assembly-wsagent-server</artifactId>
-                <version>${project.version}</version>
+                <version>${crw.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-workspaces-assembly-wsagent-war</artifactId>
-                <version>${project.version}</version>
+                <version>${crw.version}</version>
                 <type>war</type>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>ls-bayesian-agent</artifactId>
-                <version>${project.version}</version>
+                <version>${crw.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.redhat</groupId>
                 <artifactId>codeready-workspaces-assembly-wsagent-server</artifactId>
-                <version>${project.version}</version>
+                <version>${crw.version}</version>
                 <type>tar.gz</type>
             </dependency>
         </dependencies>

--- a/test/codeready-test-e2e/pom.xml
+++ b/test/codeready-test-e2e/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-test-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-test-e2e</artifactId>
     <packaging>jar</packaging>
@@ -31,12 +31,10 @@
         <dependency>
             <groupId>org.eclipse.che.selenium</groupId>
             <artifactId>che-selenium-core</artifactId>
-            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.selenium</groupId>
             <artifactId>che-selenium-test</artifactId>
-            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -61,47 +59,38 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
-            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-debug-shared</artifactId>
-            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-dto</artifactId>
-            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-model</artifactId>
-            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-system-shared</artifactId>
-            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-workspace</artifactId>
-            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-workspace-shared</artifactId>
-            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-json</artifactId>
-            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-lang</artifactId>
-            <version>${che.version}</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>

--- a/test/codeready-test-performance/pom.xml
+++ b/test/codeready-test-performance/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>codeready-test-parent</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <artifactId>codeready-test-performance</artifactId>
     <packaging>jar</packaging>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -17,12 +17,71 @@
     <parent>
         <artifactId>codeready</artifactId>
         <groupId>com.redhat</groupId>
-        <version>6.18.0</version>
+        <version>1.0.1.GA</version>
     </parent>
     <groupId>com.redhat</groupId>
     <artifactId>codeready-test-parent</artifactId>
     <packaging>pom</packaging>
     <name>CodeReady Workspaces :: Test :: Parent</name>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che.selenium</groupId>
+                <artifactId>che-selenium-core</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.selenium</groupId>
+                <artifactId>che-selenium-test</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-core</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-debug-shared</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-dto</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-model</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-system-shared</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-workspace</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-workspace-shared</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-commons-json</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-commons-lang</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <modules>
         <module>codeready-test-e2e</module>
         <module>codeready-test-performance</module>


### PR DESCRIPTION
CRW-136 use 1.0.1 version for CRW while still depending on Che 6.18 
remove versions from depmanaged deps

Change-Id: Ia0f4fb5d1275ba3e629dc7c575a0d53db049eb7a
Signed-off-by: nickboldt <nboldt@redhat.com>