### PR TITLE
Correct the e2e tests due to changed the kitchensink application

### DIFF
--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/CodeReadySplitEditorFeatureTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/CodeReadySplitEditorFeatureTest.java
@@ -25,7 +25,7 @@ public class CodeReadySplitEditorFeatureTest extends SplitEditorFeatureTest {
   protected void expandProjectExplorerAndOpenFile() {
     String javaFileName = getJavaFileNameFromTabTitle() + ".java";
     String pathTopackage =
-        PROJECT_NAME + "/src/main/java/org.jboss.as.quickstarts.kitchensink/controller";
+        PROJECT_NAME + "/src/main/java/org.jboss.as.quickstarts.kitchensinkjsp/controller";
 
     projectExplorer.expandPathInProjectExplorerAndOpenFile(pathTopackage, javaFileName);
     editor.waitTabIsPresent(getJavaFileNameFromTabTitle());
@@ -37,7 +37,7 @@ public class CodeReadySplitEditorFeatureTest extends SplitEditorFeatureTest {
   protected void waitAndSelectItem() {
     String pathToJavaFile =
         PROJECT_NAME
-            + "/src/main/java/org/jboss/as/quickstarts/kitchensink/controller/MemberRegistration.java";
+            + "/src/main/java/org/jboss/as/quickstarts/kitchensinkjsp/controller/MemberRegistration.java";
     projectExplorer.waitAndSelectItem(pathToJavaFile);
   }
 

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/CodeReadyFindTextFeatureTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/CodeReadyFindTextFeatureTest.java
@@ -46,7 +46,7 @@ public class CodeReadyFindTextFeatureTest extends FindTextFeatureTest {
     assertFalse(findTextPage.checkNextPageButtonIsEnabled());
     assertFalse(findTextPage.checkPreviousPageButtonIsEnabled());
     searchFileResult = findTextPage.getResults();
-    assertEquals(searchFileResult.getFoundFilesOnPage(), 8);
-    assertEquals(searchFileResult.getFoundOccurrencesOnPage(), 79);
+    assertEquals(searchFileResult.getFoundFilesOnPage(), 9);
+    assertEquals(searchFileResult.getFoundOccurrencesOnPage(), 73);
   }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/CodeReadyResolveDependencyAfterRecreateProjectTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/CodeReadyResolveDependencyAfterRecreateProjectTest.java
@@ -24,11 +24,11 @@ public class CodeReadyResolveDependencyAfterRecreateProjectTest
 
   @Override
   protected String getPathToExpand() {
-    return "/src/main/java/org.jboss.as.quickstarts.kitchensink/controller";
+    return "/src/main/java/org.jboss.as.quickstarts.kitchensinkjsp/controller";
   }
 
   @Override
   protected String getPathToFile() {
-    return "/src/main/java/org/jboss/as/quickstarts/kitchensink/controller/MemberRegistration.java";
+    return "/src/main/java/org/jboss/as/quickstarts/kitchensinkjsp/controller/MemberRegistration.java";
   }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
@@ -22,7 +22,6 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.A
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.QUICK_DOCUMENTATION;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.QUICK_FIX;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.utils.FileUtil.readFileToString;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR_OVERVIEW;
@@ -55,6 +54,7 @@ import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.utils.HttpUtil;
+import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Events;
 import org.eclipse.che.selenium.pageobject.Ide;
@@ -72,9 +72,15 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
   private static final String PATH_TO_MAIN_PACKAGE =
       PROJECT + "/src/main/java/org.jboss.as.quickstarts.kitchensinkjsp";
 
+  private static final String PATH_TO_DATA_PACKAGE =
+      PROJECT + "/src/main/java/org/jboss/as/quickstarts/kitchensinkjsp/data";
+
+  private static final String PATH_TO_CONTROLLER_PACKAGE =
+      PROJECT + "/src/main/java/org/jboss/as/quickstarts/kitchensinkjsp/controller";
+
   private static final String[] REPORT_DEPENDENCY_ANALYSIS = {
     "Report for /projects/spring-boot-camel/pom.xml",
-    "1) # of application dependencies : 3",
+    "1) # of application dependencies : 0",
     "2) Dependencies with Licenses : ",
     "3) Suggest adding these dependencies to your application stack:",
     "4) NO usage outlier application depedencies been found",
@@ -95,9 +101,11 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
   @Inject private NotificationsPopupPanel notifications;
   @Inject private CodereadyFindUsageWidget findUsages;
   @Inject private TestProjectServiceClient projectServiceClient;
+  @Inject private SeleniumWebDriverHelper seleniumWebDriverHelper;
 
   private final String pomFileChangedText;
   private static final String TAB_NAME_WITH_IMPL = "NativeMethodAccessorImpl";
+  private String appUrl;
 
   public JavaUserStoryTest() throws IOException, URISyntaxException {
     pomFileChangedText =
@@ -124,12 +132,15 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
     events.waitExpectedMessage("Branch 'master' is checked out");
     consoles.clickOnProcessesButton();
     consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT);
-    projectExplorer.quickRevealToItemWithJavaScript(PATH_TO_MAIN_PACKAGE);
+    ide.waitOpenedWorkspaceIsReadyToUse();
     addTestFileIntoProjectByApi();
+    projectExplorer.quickRevealToItemWithJavaScript(PATH_TO_MAIN_PACKAGE);
   }
 
   @Test(priority = 1)
-  public void checkDependencyAnalysisCommand() {
+  public void checkReportDependencyAnalysisCommand() {
+    seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
+    projectExplorer.waitAndSelectItem(PROJECT);
     commandsPalette.openCommandPalette();
     commandsPalette.startCommandByDoubleClick("dependency_analysis");
     consoles.waitExpectedTextIntoConsole(BUILD_SUCCESS);
@@ -139,6 +150,7 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
           .forEach(partOfContent -> consoles.waitExpectedTextIntoConsole(partOfContent));
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
+      seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
       fail("Known permanent failure https://issues.jboss.org/browse/CRW-123");
     }
   }
@@ -153,21 +165,20 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
    * <li>Ending of debug session
    */
   @Test(priority = 1)
-  public void checkMainDebuggerFeatures() throws Exception {
+  public void checkDebuggerFeatures() throws Exception {
     final String fileForDebuggingTabTitle = "MemberListProducer";
 
     // prepare
     setUpDebugMode();
     projectExplorer.waitItem(PROJECT);
-    projectExplorer.quickRevealToItemWithJavaScript(
-        PATH_TO_MAIN_PACKAGE + ".data/MemberListProducer.java");
+    projectExplorer.openItemByPath(PATH_TO_DATA_PACKAGE);
     projectExplorer.openItemByVisibleNameInExplorer("MemberListProducer.java");
     editor.waitActive();
     editor.waitTabIsPresent(fileForDebuggingTabTitle);
     editor.waitTabSelection(0, fileForDebuggingTabTitle);
     editor.waitActive();
     editor.setBreakPointAndWaitActiveState(30);
-    final String appUrl = doGetRequestToApp();
+    doGetRequestToApp();
 
     // check debug features()
     debugPanel.waitDebugHighlightedText("return members;");
@@ -189,8 +200,9 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
    * <li>Quick fix
    * <li>Autocompletion
    */
-  @Test(priority = 2)
-  public void checkCodeAssistantFeatures() throws Exception {
+  @Test(priority = 1)
+  public void checkMainCodeAssistantFeatures() throws Exception {
+
     String expectedTextOfInjectClass =
         "@see javax.inject.Provider\n */\n@Target({ METHOD, CONSTRUCTOR, FIELD })\n@Retention(RUNTIME)\n@Documented\npublic @interface Inject {}";
     String memberRegistrationTabName = "MemberRegistration";
@@ -208,6 +220,7 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
             "getName() : String Member",
             "Name - java.util.jar.Attributes");
 
+    projectExplorer.scrollAndSelectItem(PROJECT);
     checkGoToDeclarationFeature();
     checkFindUsagesFeature();
     checkPreviousTabFeature(memberRegistrationTabName);
@@ -225,8 +238,8 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
     }
   }
 
-  @Test(priority = 2)
-  public void checkBayesianLsErrorMarker() throws Exception {
+  @Test(priority = 1)
+  public void checkErrorMarkerBayesianLs() throws Exception {
     final String pomXmlFilePath = PROJECT + "/pom.xml";
     final String pomXmlEditorTabTitle = "jboss-as-kitchensink";
 
@@ -239,7 +252,7 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
     projectExplorer.scrollAndSelectItem(pomXmlFilePath);
     projectExplorer.waitItemIsSelected(pomXmlFilePath);
     projectExplorer.openItemByPath(pomXmlFilePath);
-    editor.waitTabIsPresent(pomXmlEditorTabTitle, WIDGET_TIMEOUT_SEC);
+    editor.waitTabIsPresent(pomXmlEditorTabTitle, LOADER_TIMEOUT_SEC);
     editor.waitTabSelection(0, pomXmlEditorTabTitle);
     editor.waitActive();
 
@@ -266,9 +279,11 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
     editor.goToPosition(23, 34);
     menu.runCommand(ASSISTANT, QUICK_FIX);
     editor.selectFirstItemIntoFixErrorPropByDoubleClick();
+    editor.waitActive();
     editor.goToPosition(24, 18);
     menu.runCommand(ASSISTANT, QUICK_FIX);
     editor.selectFirstItemIntoFixErrorPropByDoubleClick();
+    editor.waitActive();
     editor.goToPosition(84, 1);
     editor.waitTextIntoEditor(expectedTextAfterQuickFix);
   }
@@ -312,8 +327,7 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
   }
 
   private void checkGoToDeclarationFeature() {
-    projectExplorer.quickRevealToItemWithJavaScript(
-        PATH_TO_MAIN_PACKAGE + ".controller/MemberRegistration.java");
+    projectExplorer.openItemByPath(PATH_TO_CONTROLLER_PACKAGE);
     projectExplorer.openItemByVisibleNameInExplorer("MemberRegistration.java");
     editor.waitActive();
     editor.goToPosition(34, 14);
@@ -323,6 +337,7 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
   }
 
   private void setUpDebugMode() {
+    projectExplorer.scrollAndSelectItem(PROJECT);
     commandsPalette.openCommandPalette();
     commandsPalette.startCommandByDoubleClick("kitchensink-example:build and run in debug");
     consoles.waitExpectedTextIntoConsole("started in");
@@ -339,17 +354,14 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
     events.clickEventLogBtn();
     events.waitExpectedMessage("Remote debugger connected");
     consoles.clickOnProcessesButton();
+    appUrl = consoles.getPreviewUrl();
   }
 
   // do request to test application if debugger for the app. has been set properly,
   // expected http response from the app. will be 504, its ok
   private String doGetRequestToApp() {
-    final String appUrl = consoles.getPreviewUrl() + "/index.jsf";
-    int responseCode = -1;
-
     try {
-      responseCode = HttpUtil.getUrlResponseCode(appUrl);
-
+      int responseCode = HttpUtil.getUrlResponseCode(appUrl);
       // The "504" response code it is expected
       if (504 == responseCode) {
         LOG.info("Debugger has been set");
@@ -395,12 +407,13 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
     debugPanel.waitDebugHighlightedText("return ma.invoke(obj, args);");
   }
 
-  private void checkFramesAndVariablesWithResume() {
+  private void checkFramesAndVariablesWithResume() throws IOException {
     Stream<String> expectedValuesInVariablesWidget =
         Stream.of(
             "em=instance of org.jboss.as.jpa.container.TransactionScopedEntityManager",
             "members=instance of java.util.ArrayList");
     editor.closeAllTabs();
+    doGetRequestToApp();
     debugPanel.clickOnButton(RESUME_BTN_ID);
     editor.waitTabIsPresent("MemberListProducer");
     debugPanel.waitDebugHighlightedText("return members;");

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
@@ -79,7 +79,7 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
       PROJECT + "/src/main/java/org/jboss/as/quickstarts/kitchensinkjsp/controller";
 
   private static final String[] REPORT_DEPENDENCY_ANALYSIS = {
-    "Report for /projects/spring-boot-camel/pom.xml",
+    "Report for /projects/kitchensink-example/pom.xml",
     "1) # of application dependencies : 0",
     "2) Dependencies with Licenses : ",
     "3) Suggest adding these dependencies to your application stack:",

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/RedHatFuseUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/RedHatFuseUserStoryTest.java
@@ -51,7 +51,7 @@ public class RedHatFuseUserStoryTest extends AbstractUserStoryTest {
 
   private static final String[] REPORT_DEPENDENCY_ANALYSIS = {
     "Report for /projects/spring-boot-camel/pom.xml",
-    "1) # of application dependencies : 3",
+    "1) # of application dependencies : 4",
     "2) Dependencies with Licenses : ",
     "3) Suggest adding these dependencies to your application stack:",
     "4) NO usage outlier application depedencies been found",

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/VertxUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/VertxUserStoryTest.java
@@ -21,6 +21,7 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.A
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.BUILD_GOAL;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.DEBUG_GOAL;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.RUN_GOAL;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.UPDATING_PROJECT_TIMEOUT_SEC;
@@ -90,8 +91,7 @@ public class VertxUserStoryTest extends AbstractUserStoryTest {
 
     // wait expected message in the progress info bar
     // the execution takes a lot of time on a local machine, so need a big timeout
-    mavenPluginStatusBar.waitExpectedTextInInfoPanel(
-        "Importing Maven project(s)", LOADER_TIMEOUT_SEC);
+    mavenPluginStatusBar.waitExpectedTextInInfoPanel("Refreshing Maven model", ELEMENT_TIMEOUT_SEC);
     mavenPluginStatusBar.waitClosingInfoPanel(PREPARING_WS_TIMEOUT_SEC);
 
     // check the project is initialized
@@ -121,7 +121,7 @@ public class VertxUserStoryTest extends AbstractUserStoryTest {
 
     // wait expected message in the progress info bar
     // the execution take a lot of time on a local machine, so need a big timeout
-    mavenPluginStatusBar.waitExpectedTextInInfoPanel("Download sources and javadoc:", 620);
+    mavenPluginStatusBar.waitExpectedTextInInfoPanel("Download sources and javadoc:", 120);
     mavenPluginStatusBar.waitClosingInfoPanel(UPDATING_PROJECT_TIMEOUT_SEC);
 
     projectExplorer.expandPathInProjectExplorerAndOpenFile(

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/VertxUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/VertxUserStoryTest.java
@@ -22,6 +22,7 @@ import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextM
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.DEBUG_GOAL;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.RUN_GOAL;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.UPDATING_PROJECT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
 
@@ -89,15 +90,16 @@ public class VertxUserStoryTest extends AbstractUserStoryTest {
 
     // wait expected message in the progress info bar
     // the execution takes a lot of time on a local machine, so need a big timeout
-    mavenPluginStatusBar.waitExpectedTextInInfoPanel("Refreshing Maven model", LOADER_TIMEOUT_SEC);
-    mavenPluginStatusBar.waitClosingInfoPanel();
+    mavenPluginStatusBar.waitExpectedTextInInfoPanel(
+        "Importing Maven project(s)", LOADER_TIMEOUT_SEC);
+    mavenPluginStatusBar.waitClosingInfoPanel(PREPARING_WS_TIMEOUT_SEC);
 
     // check the project is initialized
     projectExplorer.waitProjectInitialization(VERTX_PROJECT_NAME);
   }
 
-  @Test(priority = 1)
-  public void checkDependencyAnalysisCommand() {
+  @Test(priority = 2)
+  public void checkReportDependencyAnalysisCommand() {
     commandsPalette.openCommandPalette();
     commandsPalette.startCommandByDoubleClick("dependency_analysis");
     consoles.waitExpectedTextIntoConsole(BUILD_SUCCESS);

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/workspaces/CodeReadyCreateWorkspaceOnDashboardTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/workspaces/CodeReadyCreateWorkspaceOnDashboardTest.java
@@ -22,12 +22,12 @@ public class CodeReadyCreateWorkspaceOnDashboardTest extends CreateWorkspaceOnDa
 
   @Override
   protected String getPathToExpand() {
-    return "/src/main/java/org.jboss.as.quickstarts.kitchensink/controller";
+    return "/src/main/java/org.jboss.as.quickstarts.kitchensinkjsp/controller";
   }
 
   @Override
   protected String getPathJavaFile() {
-    return "/src/main/java/org/jboss/as/quickstarts/kitchensink/controller/MemberRegistration.java";
+    return "/src/main/java/org/jboss/as/quickstarts/kitchensinkjsp/controller/MemberRegistration.java";
   }
 
   @Override

--- a/test/codeready-test-e2e/src/test/resources/projects/Decorator.java
+++ b/test/codeready-test-e2e/src/test/resources/projects/Decorator.java
@@ -9,7 +9,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.jboss.as.quickstarts.kitchensink.util;
+package org.jboss.as.quickstarts.kitchensinkjsp.util;
 
 public interface DecoratorSample {
     String decorate(String s);

--- a/test/codeready-test-e2e/src/test/resources/suites/CheSuite.xml
+++ b/test/codeready-test-e2e/src/test/resources/suites/CheSuite.xml
@@ -37,11 +37,11 @@
           <class name="com.redhat.codeready.selenium.debugger.CodeReadyPhpProjectDebuggingTest"/>
           <class name="com.redhat.codeready.selenium.debugger.CodeReadyStepIntoStepOverStepReturnWithChangeVariableTest"/>
           <class name="com.redhat.codeready.selenium.git.ImportWizardFormTest"/>
-          <class name="com.redhat.codeready.selenium.miscellaneous.FindTextFeatureTest"/>
-          <class name="com.redhat.codeready.selenium.miscellaneous.OpenInTerminalTest"/>
-          <class name="com.redhat.codeready.selenium.miscellaneous.ResolveDependencyAfterRecreateProjectTest"/>
-          <class name="com.redhat.codeready.selenium.miscellaneous.WorkingWithSplitPanelTest"/>
-          <class name="com.redhat.codeready.selenium.miscellaneous.WorkingWithTerminalTest"/>
+          <class name="com.redhat.codeready.selenium.miscellaneous.CodeReadyFindTextFeatureTest"/>
+          <class name="com.redhat.codeready.selenium.miscellaneous.CodeReadyOpenInTerminalTest"/>
+          <class name="com.redhat.codeready.selenium.miscellaneous.CodeReadyResolveDependencyAfterRecreateProjectTest"/>
+          <class name="com.redhat.codeready.selenium.miscellaneous.CodeReadyWorkingWithSplitPanelTest"/>
+          <class name="com.redhat.codeready.selenium.miscellaneous.CodeReadyWorkingWithTerminalTest"/>
           <class name="com.redhat.codeready.selenium.miscellaneous.MachinesAsynchronousStartTest"/>
           <class name="com.redhat.codeready.selenium.factory.CodeReadyCheckOpenFileFeatureTest"/>
           <class name="com.redhat.codeready.selenium.factory.CodeReadyCheckRunCommandFeatureTest"/>
@@ -54,7 +54,7 @@
           <class name="com.redhat.codeready.selenium.languageserver.CodeReadyGolangFileEditingTest"/>
           <class name="com.redhat.codeready.selenium.languageserver.csharp.CodeReadyCSharpFileEditingTest"/>
           <class name="com.redhat.codeready.selenium.languageserver.php.CodeReadyPhpFileEditingTest"/>
-          <class name="com.redhat.codeready.selenium.workspaces.CreateWorkspaceOnDashboardTest"/>
+          <class name="com.redhat.codeready.selenium.workspaces.CodeReadyCreateWorkspaceOnDashboardTest"/>
           <class name="com.redhat.codeready.selenium.editor.CodeReadySplitEditorFeatureTest"/>
           <class name="com.redhat.codeready.selenium.editor.autocomplete.CodeReadyAutocompleteProposalJavaDocTest"/>
           <class name="com.redhat.codeready.selenium.projectexplorer.CodeReadyCheckShowHideHiddenFilesTest"/>


### PR DESCRIPTION
It is version of another PR https://github.com/redhat-developer/codeready-workspaces/pull/93 made by @artaleks9 without redundant commits.
It includes:
* Correct the tests related to change the template application
* Correct the tests to provide success execution

Test results could be found [here|https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/pre-release-user-stories-e2e-tests-against-OCP/6/].

Signed-off-by: Dmytro Nochevnov <dnochevn@redhat.com>