### PR TITLE
 Fix blank screenshots in e2e tests result report

### DIFF
--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaEapUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaEapUserStoryTest.java
@@ -14,15 +14,9 @@ package com.redhat.codeready.selenium.userstory;
 import static com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWorkspace.CodereadyStacks.JAVA_EAP;
 
 import com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWorkspace;
-import java.io.IOException;
-import java.net.URISyntaxException;
 
 /** @author Musienko Maxim */
 public class JavaEapUserStoryTest extends JavaUserStoryTest {
-
-  public JavaEapUserStoryTest() throws IOException, URISyntaxException {
-    super();
-  }
 
   @Override
   protected CodereadyNewWorkspace.CodereadyStacks getStackName() {

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaEapUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaEapUserStoryTest.java
@@ -14,6 +14,7 @@ package com.redhat.codeready.selenium.userstory;
 import static com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWorkspace.CodereadyStacks.JAVA_EAP;
 
 import com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWorkspace;
+import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
 public class JavaEapUserStoryTest extends JavaUserStoryTest {
@@ -21,5 +22,30 @@ public class JavaEapUserStoryTest extends JavaUserStoryTest {
   @Override
   protected CodereadyNewWorkspace.CodereadyStacks getStackName() {
     return JAVA_EAP;
+  }
+
+  @Test
+  public void createWorkspaceFromDashboard() throws Exception {
+    super.createWorkspaceFromDashboard();
+  }
+
+  @Test(priority = 1)
+  public void checkDependencyAnalysisCommand() {
+    super.checkDependencyAnalysisCommand();
+  }
+
+  @Test(priority = 1)
+  public void checkDebuggerFeatures() throws Exception {
+    super.checkDebuggerFeatures();
+  }
+
+  @Test(priority = 1)
+  public void checkMainCodeAssistantFeatures() throws Exception {
+    super.checkMainCodeAssistantFeatures();
+  }
+
+  @Test(priority = 1)
+  public void checkErrorMarkerBayesianLs() throws Exception {
+    super.checkErrorMarkerBayesianLs();
   }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaEapUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaEapUserStoryTest.java
@@ -16,7 +16,11 @@ import static com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWor
 import com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWorkspace;
 import org.testng.annotations.Test;
 
-/** @author Musienko Maxim */
+/**
+ * @author Musienko Maxim
+ *     <p>Note: test are being overrided in class to support proper sequence of tests (issue
+ *     CRW-155).
+ */
 public class JavaEapUserStoryTest extends JavaUserStoryTest {
 
   @Override
@@ -25,26 +29,31 @@ public class JavaEapUserStoryTest extends JavaUserStoryTest {
   }
 
   @Test
+  @Override
   public void createWorkspaceFromDashboard() throws Exception {
     super.createWorkspaceFromDashboard();
   }
 
   @Test(priority = 1)
+  @Override
   public void checkDependencyAnalysisCommand() {
     super.checkDependencyAnalysisCommand();
   }
 
   @Test(priority = 1)
+  @Override
   public void checkDebuggerFeatures() throws Exception {
     super.checkDebuggerFeatures();
   }
 
   @Test(priority = 1)
+  @Override
   public void checkMainCodeAssistantFeatures() throws Exception {
     super.checkMainCodeAssistantFeatures();
   }
 
   @Test(priority = 1)
+  @Override
   public void checkErrorMarkerBayesianLs() throws Exception {
     super.checkErrorMarkerBayesianLs();
   }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
@@ -42,7 +42,6 @@ import com.redhat.codeready.selenium.pageobject.CodereadyEditor;
 import com.redhat.codeready.selenium.pageobject.dashboard.CodereadyFindUsageWidget;
 import com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWorkspace;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -103,14 +102,8 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
   @Inject private TestProjectServiceClient projectServiceClient;
   @Inject private SeleniumWebDriverHelper seleniumWebDriverHelper;
 
-  private final String pomFileChangedText;
   private static final String TAB_NAME_WITH_IMPL = "NativeMethodAccessorImpl";
   private String appUrl;
-
-  public JavaUserStoryTest() throws IOException, URISyntaxException {
-    pomFileChangedText =
-        readFileToString(getClass().getResource("/projects/bayesian/pom-file-after.txt"));
-  }
 
   @Override
   protected CodereadyNewWorkspace.CodereadyStacks getStackName() {
@@ -243,6 +236,8 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
     // open file
     seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
     projectExplorer.waitItem(PROJECT);
+    String pomFileChangedText =
+        readFileToString(getClass().getResource("/projects/bayesian/pom-file-after.txt"));
     projectServiceClient.updateFile(testWorkspace.getId(), pomXmlFilePath, pomFileChangedText);
     projectExplorer.scrollAndSelectItem(pomXmlFilePath);
     projectExplorer.waitItemIsSelected(pomXmlFilePath);

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
@@ -15,6 +15,7 @@ import static com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWor
 import static java.nio.file.Files.readAllLines;
 import static java.nio.file.Paths.get;
 import static java.util.Arrays.stream;
+import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.core.constant.TestBuildConstants.BUILD_SUCCESS;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_DEFINITION;
@@ -39,6 +40,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.redhat.codeready.selenium.pageobject.CodereadyDebuggerPanel;
 import com.redhat.codeready.selenium.pageobject.CodereadyEditor;
+import com.redhat.codeready.selenium.pageobject.dashboard.CodeReadyCreateWorkspaceHelper;
 import com.redhat.codeready.selenium.pageobject.dashboard.CodereadyFindUsageWidget;
 import com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWorkspace;
 import java.io.IOException;
@@ -54,19 +56,32 @@ import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.utils.HttpUtil;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
+import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Events;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
+import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.debug.JavaDebugConfig;
 import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
 import org.openqa.selenium.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-/** @author Musienko Maxim */
-public class JavaUserStoryTest extends AbstractUserStoryTest {
+/**
+ * @author Musienko Maxim
+ *     <p>(can't be extened from AbstractUserStoryTest to support proper sequence of test being
+ *     executed (issue CRW-))
+ */
+public class JavaUserStoryTest {
+  protected final Logger LOG = LoggerFactory.getLogger(this.getClass());
+  protected final String WORKSPACE = generate(this.getClass().getSimpleName(), 4);
+
   private static final String PROJECT = "kitchensink-example";
   private static final String PATH_TO_MAIN_PACKAGE =
       PROJECT + "/src/main/java/org.jboss.as.quickstarts.kitchensinkjsp";
@@ -99,26 +114,47 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
   @Inject private Events events;
   @Inject private NotificationsPopupPanel notifications;
   @Inject private CodereadyFindUsageWidget findUsages;
+  @Inject private Dashboard dashboard;
   @Inject private TestProjectServiceClient projectServiceClient;
   @Inject private SeleniumWebDriverHelper seleniumWebDriverHelper;
+  @Inject private CodeReadyCreateWorkspaceHelper codeReadyCreateWorkspaceHelper;
 
   private static final String TAB_NAME_WITH_IMPL = "NativeMethodAccessorImpl";
   private String appUrl;
 
-  @Override
   protected CodereadyNewWorkspace.CodereadyStacks getStackName() {
     return JAVA_DEFAULT;
   }
 
-  @Override
   protected List<String> getProjects() {
     return ImmutableList.of(PROJECT);
   }
 
-  @Override
+  // it is used to read workspace logs on test failure
+  protected TestWorkspace testWorkspace;
+
+  private String currentWindow;
+
+  @BeforeClass
+  public void setUp() {
+    dashboard.open();
+  }
+
+  @AfterClass
+  public void tearDown() throws Exception {
+    workspaceServiceClient.delete(WORKSPACE, defaultTestUser.getName());
+  }
+
   @Test
   public void createWorkspaceFromDashboard() throws Exception {
-    super.createWorkspaceFromDashboard();
+    testWorkspace =
+        codeReadyCreateWorkspaceHelper.createWsFromStackWithTestProject(
+            WORKSPACE, getStackName(), getProjects());
+
+    // switch to the IDE
+    currentWindow = ide.switchToIdeAndWaitWorkspaceIsReadyToUse();
+
+    getProjects().forEach(projectExplorer::waitProjectInitialization);
 
     projectExplorer.waitItem(PROJECT);
     events.clickEventLogBtn();

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
@@ -15,7 +15,6 @@ import static com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWor
 import static java.nio.file.Files.readAllLines;
 import static java.nio.file.Paths.get;
 import static java.util.Arrays.stream;
-import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.core.constant.TestBuildConstants.BUILD_SUCCESS;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_DEFINITION;
@@ -40,7 +39,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.redhat.codeready.selenium.pageobject.CodereadyDebuggerPanel;
 import com.redhat.codeready.selenium.pageobject.CodereadyEditor;
-import com.redhat.codeready.selenium.pageobject.dashboard.CodeReadyCreateWorkspaceHelper;
 import com.redhat.codeready.selenium.pageobject.dashboard.CodereadyFindUsageWidget;
 import com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWorkspace;
 import java.io.IOException;
@@ -56,32 +54,19 @@ import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.utils.HttpUtil;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
-import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Events;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.debug.JavaDebugConfig;
 import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
 import org.openqa.selenium.TimeoutException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-/**
- * @author Musienko Maxim
- *     <p>(can't be extened from AbstractUserStoryTest to support proper sequence of test being
- *     executed (issue CRW-))
- */
-public class JavaUserStoryTest {
-  protected final Logger LOG = LoggerFactory.getLogger(this.getClass());
-  protected final String WORKSPACE = generate(this.getClass().getSimpleName(), 4);
-
+/** @author Musienko Maxim */
+public class JavaUserStoryTest extends AbstractUserStoryTest {
   private static final String PROJECT = "kitchensink-example";
   private static final String PATH_TO_MAIN_PACKAGE =
       PROJECT + "/src/main/java/org.jboss.as.quickstarts.kitchensinkjsp";
@@ -114,47 +99,26 @@ public class JavaUserStoryTest {
   @Inject private Events events;
   @Inject private NotificationsPopupPanel notifications;
   @Inject private CodereadyFindUsageWidget findUsages;
-  @Inject private Dashboard dashboard;
   @Inject private TestProjectServiceClient projectServiceClient;
   @Inject private SeleniumWebDriverHelper seleniumWebDriverHelper;
-  @Inject private CodeReadyCreateWorkspaceHelper codeReadyCreateWorkspaceHelper;
 
   private static final String TAB_NAME_WITH_IMPL = "NativeMethodAccessorImpl";
   private String appUrl;
 
+  @Override
   protected CodereadyNewWorkspace.CodereadyStacks getStackName() {
     return JAVA_DEFAULT;
   }
 
+  @Override
   protected List<String> getProjects() {
     return ImmutableList.of(PROJECT);
   }
 
-  // it is used to read workspace logs on test failure
-  protected TestWorkspace testWorkspace;
-
-  private String currentWindow;
-
-  @BeforeClass
-  public void setUp() {
-    dashboard.open();
-  }
-
-  @AfterClass
-  public void tearDown() throws Exception {
-    workspaceServiceClient.delete(WORKSPACE, defaultTestUser.getName());
-  }
-
+  @Override
   @Test
   public void createWorkspaceFromDashboard() throws Exception {
-    testWorkspace =
-        codeReadyCreateWorkspaceHelper.createWsFromStackWithTestProject(
-            WORKSPACE, getStackName(), getProjects());
-
-    // switch to the IDE
-    currentWindow = ide.switchToIdeAndWaitWorkspaceIsReadyToUse();
-
-    getProjects().forEach(projectExplorer::waitProjectInitialization);
+    super.createWorkspaceFromDashboard();
 
     projectExplorer.waitItem(PROJECT);
     events.clickEventLogBtn();

--- a/test/codeready-test-e2e/src/test/resources/suites/CodereadyOneThreadTestsSuite.xml
+++ b/test/codeready-test-e2e/src/test/resources/suites/CodereadyOneThreadTestsSuite.xml
@@ -18,19 +18,6 @@
        thread-count="1">
     <test name="all">
         <classes>
-            <class name="com.redhat.codeready.selenium.userstory.JavaUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.NodeJsUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.PythonUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.GoUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.PhpUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.VertxUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.SpringBootUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.DotNetUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.JavaEapUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.ClangCppUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.RedHatFuseUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.WildFlyUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.JavaRhel8UserStoryTest"/>
         </classes>
     </test>
 </suite>

--- a/test/codeready-test-e2e/src/test/resources/suites/CodereadyOneThreadTestsSuite.xml
+++ b/test/codeready-test-e2e/src/test/resources/suites/CodereadyOneThreadTestsSuite.xml
@@ -18,6 +18,19 @@
        thread-count="1">
     <test name="all">
         <classes>
+            <class name="com.redhat.codeready.selenium.userstory.JavaUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.NodeJsUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.PythonUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.GoUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.PhpUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.VertxUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.SpringBootUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.DotNetUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.JavaEapUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.ClangCppUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.RedHatFuseUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.WildFlyUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.JavaRhel8UserStoryTest"/>
         </classes>
     </test>
 </suite>

--- a/test/codeready-test-e2e/src/test/resources/suites/CodereadySuite.xml
+++ b/test/codeready-test-e2e/src/test/resources/suites/CodereadySuite.xml
@@ -19,19 +19,6 @@
 
     <test name="all">
         <classes>
-            <class name="com.redhat.codeready.selenium.userstory.JavaEapUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.JavaUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.NodeJsUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.PythonUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.GoUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.PhpUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.VertxUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.SpringBootUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.DotNetUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.ClangCppUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.RedHatFuseUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.WildFlyUserStoryTest"/>
-            <class name="com.redhat.codeready.selenium.userstory.JavaRhel8UserStoryTest"/>
         </classes>
     </test>
 

--- a/test/codeready-test-e2e/src/test/resources/suites/CodereadySuite.xml
+++ b/test/codeready-test-e2e/src/test/resources/suites/CodereadySuite.xml
@@ -19,6 +19,19 @@
 
     <test name="all">
         <classes>
+            <class name="com.redhat.codeready.selenium.userstory.JavaUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.NodeJsUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.PythonUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.GoUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.PhpUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.VertxUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.SpringBootUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.DotNetUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.JavaEapUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.ClangCppUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.RedHatFuseUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.WildFlyUserStoryTest"/>
+            <class name="com.redhat.codeready.selenium.userstory.JavaRhel8UserStoryTest"/>
         </classes>
     </test>
 


### PR DESCRIPTION
There are flaky e2e user story tests of class JavaEapUserStoryTest, which are failing with blank pages. For example:
https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/CRW-pre-release-tests/job/pre-release-user-stories-e2e-tests-against-OCP/20/E2E_20tests_20report/

It happens with inherited tests which have more one test method and 
when they are performed in a test suite or in a package (if you'll launch as a single test it is not reproduced).

This PR describes test methods inside the **JavaEapUserStoryTest** class explicitly, rather then inherit it from **JavaUserStoryTest** implicitly. 
Resulted test report could be found [here](https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/CRW-pre-release-tests/job/pre-release-user-stories-e2e-tests-against-OCP/31/E2E_20tests_20report/failsafe-report.html#com.redhat.codeready.selenium.userstoryJavaEapUserStoryTest).