### PR TITLE
Test E2E: Fix blank screenshots in e2e tests result report

### DIFF
--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyPhpProjectDebuggingTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyPhpProjectDebuggingTest.java
@@ -19,9 +19,9 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
- * @author Dmytro Nochevnov
+ * @author Dmytro Nochevnov@
  * @author Aleksandr Shmaraiev
- *     <p>Note: test are being overrided in class to support proper sequence of tests (issue *
+ *     <p>Note: test are being overrided in class to support proper sequence of tests (issue
  *     CRW-155).
  */
 public class CodeReadyPhpProjectDebuggingTest extends PhpProjectDebuggingTest {

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyPhpProjectDebuggingTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyPhpProjectDebuggingTest.java
@@ -14,10 +14,15 @@ package com.redhat.codeready.selenium.debugger;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.COMMON_GOAL;
 
 import org.eclipse.che.selenium.debugger.PhpProjectDebuggingTest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 /**
  * @author Dmytro Nochevnov
  * @author Aleksandr Shmaraiev
+ *     <p>Note: test are being overrided in class to support proper sequence of tests (issue *
+ *     CRW-155).
  */
 public class CodeReadyPhpProjectDebuggingTest extends PhpProjectDebuggingTest {
 
@@ -29,5 +34,29 @@ public class CodeReadyPhpProjectDebuggingTest extends PhpProjectDebuggingTest {
   @Override
   protected void invokeStopCommandWithContextMenu() {
     projectExplorer.invokeCommandWithContextMenu(COMMON_GOAL, PROJECT, "stop httpd");
+  }
+
+  @BeforeMethod
+  @Override
+  public void startDebug() {
+    super.startDebug();
+  }
+
+  @AfterMethod
+  @Override
+  public void stopDebug() {
+    super.stopDebug();
+  }
+
+  @Test
+  @Override
+  public void shouldDebugCliPhpScriptFromFirstLine() {
+    super.shouldDebugCliPhpScriptFromFirstLine();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void shouldDebugWebPhpScriptFromNonDefaultPortAndNotFromFirstLine() {
+    super.shouldDebugWebPhpScriptFromNonDefaultPortAndNotFromFirstLine();
   }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyStepIntoStepOverStepReturnWithChangeVariableTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyStepIntoStepOverStepReturnWithChangeVariableTest.java
@@ -13,10 +13,14 @@ package com.redhat.codeready.selenium.debugger;
 
 import org.eclipse.che.selenium.core.constant.TestCommandsConstants;
 import org.eclipse.che.selenium.debugger.StepIntoStepOverStepReturnWithChangeVariableTest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
 
 /**
  * @author Dmytro Nochevnov
  * @author Aleksandr Shmaraiev
+ *     <p>Note: test are being overrided in class to support proper sequence of tests (issue * *
+ *     CRW-155).
  */
 public class CodeReadyStepIntoStepOverStepReturnWithChangeVariableTest
     extends StepIntoStepOverStepReturnWithChangeVariableTest {
@@ -61,5 +65,23 @@ public class CodeReadyStepIntoStepOverStepReturnWithChangeVariableTest
             .getUrl()
             .replace("tcp", "http")
         + "/spring/guess";
+  }
+
+  @AfterMethod
+  @Override
+  public void shutDownAndCleanWebApp() {
+    super.shutDownAndCleanWebApp();
+  }
+
+  @Test
+  @Override
+  public void changeVariableTest() throws Exception {
+    super.changeVariableTest();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void shouldOpenDebuggingFile() {
+    super.shouldOpenDebuggingFile();
   }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyStepIntoStepOverStepReturnWithChangeVariableTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyStepIntoStepOverStepReturnWithChangeVariableTest.java
@@ -19,7 +19,7 @@ import org.testng.annotations.Test;
 /**
  * @author Dmytro Nochevnov
  * @author Aleksandr Shmaraiev
- *     <p>Note: test are being overrided in class to support proper sequence of tests (issue * *
+ *     <p>Note: test are being overrided in class to support proper sequence of tests (issue
  *     CRW-155).
  */
 public class CodeReadyStepIntoStepOverStepReturnWithChangeVariableTest

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/CodeReadySplitEditorFeatureTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/CodeReadySplitEditorFeatureTest.java
@@ -12,8 +12,13 @@
 package com.redhat.codeready.selenium.editor;
 
 import org.eclipse.che.selenium.editor.SplitEditorFeatureTest;
+import org.testng.annotations.Test;
 
-/** @author Aleksandr Shmaraiev */
+/**
+ * @author Aleksandr Shmaraev
+ *     <p>Note: test are being overrided in class to support proper sequence of tests (issue
+ *     CRW-155).
+ */
 public class CodeReadySplitEditorFeatureTest extends SplitEditorFeatureTest {
 
   @Override
@@ -45,5 +50,29 @@ public class CodeReadySplitEditorFeatureTest extends SplitEditorFeatureTest {
   protected void selectSample() {
     String sampleName = "kitchensink-example";
     wizard.selectSample(sampleName);
+  }
+
+  @Test
+  @Override
+  public void checkSplitEditorWindow() {
+    super.checkSplitEditorWindow();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkFocusInCurrentWindow() {
+    super.checkFocusInCurrentWindow();
+  }
+
+  @Test(priority = 2)
+  @Override
+  public void checkRefactoring() {
+    super.checkRefactoring();
+  }
+
+  @Test(priority = 3)
+  @Override
+  public void checkContentAfterRenameFile() {
+    super.checkContentAfterRenameFile();
   }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/autocomplete/CodeReadyAutocompleteProposalJavaDocTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/autocomplete/CodeReadyAutocompleteProposalJavaDocTest.java
@@ -15,6 +15,11 @@ import org.eclipse.che.selenium.editor.autocomplete.AutocompleteProposalJavaDocT
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+/**
+ * @author Aleksandr Shmaraev
+ *     <p>Note: test are being overrided in class to support proper sequence of tests (issue
+ *     CRW-155).
+ */
 public class CodeReadyAutocompleteProposalJavaDocTest extends AutocompleteProposalJavaDocTest {
 
   @Override

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/autocomplete/CodeReadyAutocompleteProposalJavaDocTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/autocomplete/CodeReadyAutocompleteProposalJavaDocTest.java
@@ -12,6 +12,8 @@
 package com.redhat.codeready.selenium.editor.autocomplete;
 
 import org.eclipse.che.selenium.editor.autocomplete.AutocompleteProposalJavaDocTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 public class CodeReadyAutocompleteProposalJavaDocTest extends AutocompleteProposalJavaDocTest {
 
@@ -59,5 +61,47 @@ public class CodeReadyAutocompleteProposalJavaDocTest extends AutocompletePropos
         + "</li>\n"
         + "<li><p><strong>See Also:</strong></p>\n"
         + "<ul>\n";
+  }
+
+  @BeforeMethod
+  @Override
+  public void openMainClass() {
+    super.openMainClass();
+  }
+
+  @Test
+  @Override
+  public void shouldDisplayJavaDocOfClassMethod() {
+    super.shouldDisplayJavaDocOfClassMethod();
+  }
+
+  @Test
+  @Override
+  public void shouldWorkAroundAbsentJavaDocOfConstructor() {
+    super.shouldWorkAroundAbsentJavaDocOfConstructor();
+  }
+
+  @Test
+  @Override
+  public void shouldDisplayAnotherModuleClassJavaDoc() {
+    super.shouldDisplayAnotherModuleClassJavaDoc();
+  }
+
+  @Test
+  @Override
+  public void shouldReflectChangesInJavaDoc() {
+    super.shouldReflectChangesInJavaDoc();
+  }
+
+  @Test
+  @Override
+  public void shouldDisplayJavaDocOfJreClass() {
+    super.shouldDisplayJavaDocOfJreClass();
+  }
+
+  @Test
+  @Override
+  public void shouldNotShowJavaDocIfExternalLibDoesNotExist() {
+    super.shouldNotShowJavaDocIfExternalLibDoesNotExist();
   }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyAutocompleteCommandsEditorTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyAutocompleteCommandsEditorTest.java
@@ -12,8 +12,13 @@
 package com.redhat.codeready.selenium.intelligencecommand;
 
 import org.eclipse.che.selenium.intelligencecommand.AutocompleteCommandsEditorTest;
+import org.testng.annotations.Test;
 
-/** @author Aleksandr Shmaraev */
+/**
+ * @author Aleksandr Shmaraev
+ *     <p>Note: test are being overrided in class to support proper sequence of tests (issue
+ *     CRW-155).
+ */
 public class CodeReadyAutocompleteCommandsEditorTest extends AutocompleteCommandsEditorTest {
 
   @Override
@@ -47,5 +52,23 @@ public class CodeReadyAutocompleteCommandsEditorTest extends AutocompleteCommand
   protected void typeTextInEditorAndLaunchAutocomplete() {
     commandsEditor.typeTextIntoEditor("server.wsagent");
     commandsEditor.launchAutocompleteAndWaitContainer();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkAutocompleteCommandLine() {
+    super.checkAutocompleteCommandLine();
+  }
+
+  @Test(priority = 2)
+  @Override
+  public void checkAutocompletePreviewUrl() {
+    super.checkAutocompletePreviewUrl();
+  }
+
+  @Test(priority = 3)
+  @Override
+  public void checkAutocompleteAfterSave() {
+    super.checkAutocompleteAfterSave();
   }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyCheckIntelligenceCommandFromToolbarTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyCheckIntelligenceCommandFromToolbarTest.java
@@ -12,8 +12,8 @@
 package com.redhat.codeready.selenium.intelligencecommand;
 
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 
 import org.eclipse.che.selenium.intelligencecommand.CheckIntelligenceCommandFromToolbarTest;
 import org.openqa.selenium.By;
@@ -22,15 +22,13 @@ import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.annotations.Test;
 
-/** @author Aleksandr Shmaraev */
+/**
+ * @author Aleksandr Shmaraev
+ *     <p>Note: test are being overrided in class to support proper sequence of tests (issue
+ *     CRW-155).
+ */
 public class CodeReadyCheckIntelligenceCommandFromToolbarTest
     extends CheckIntelligenceCommandFromToolbarTest {
-
-  @Override
-  @Test(priority = 1)
-  public void checkButtonsOnToolbarOnOpenshift() {
-    checkButtonsOnToolbar("Application is not available");
-  }
 
   @Override
   protected void checkButtonsOnToolbar(String expectedText) {
@@ -38,7 +36,7 @@ public class CodeReadyCheckIntelligenceCommandFromToolbarTest
     projectExplorer.waitItem(PROJECT_NAME);
     commandsToolbar.clickExecStopBtn();
 
-    checkTestAppByPreviewUrlAndReturnToIde(currentWindow, expectedText);
+    super.checkTestAppByPreviewUrlAndReturnToIde(currentWindow, expectedText);
     commandsToolbar.clickExecRerunBtn();
     waitExpectedTextIntoConsole();
     consoles.clickOnPreviewUrl();
@@ -71,7 +69,7 @@ public class CodeReadyCheckIntelligenceCommandFromToolbarTest
 
   @Override
   protected void waitExpectedTextIntoConsole() {
-    consoles.waitExpectedTextIntoConsole("started in", WIDGET_TIMEOUT_SEC);
+    consoles.waitExpectedTextIntoConsole("started in", EXPECTED_MESS_IN_CONSOLE_SEC);
   }
 
   @Override
@@ -128,5 +126,17 @@ public class CodeReadyCheckIntelligenceCommandFromToolbarTest
   @Override
   protected String getBodyText() {
     return seleniumWebDriverHelper.waitVisibilityAndGetText(By.tagName("body"));
+  }
+
+  @Test
+  @Override
+  public void launchClonedWepAppTest() {
+    super.launchClonedWepAppTest();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkButtonsOnToolbarOnOpenshift() {
+    checkButtonsOnToolbar("Application is not available");
   }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyCheckIntelligenceCommandFromToolbarTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyCheckIntelligenceCommandFromToolbarTest.java
@@ -13,7 +13,6 @@ package com.redhat.codeready.selenium.intelligencecommand;
 
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 
 import org.eclipse.che.selenium.intelligencecommand.CheckIntelligenceCommandFromToolbarTest;
 import org.openqa.selenium.By;
@@ -36,7 +35,7 @@ public class CodeReadyCheckIntelligenceCommandFromToolbarTest
     projectExplorer.waitItem(PROJECT_NAME);
     commandsToolbar.clickExecStopBtn();
 
-    super.checkTestAppByPreviewUrlAndReturnToIde(currentWindow, expectedText);
+    checkTestAppByPreviewUrlAndReturnToIde(currentWindow, expectedText);
     commandsToolbar.clickExecRerunBtn();
     waitExpectedTextIntoConsole();
     consoles.clickOnPreviewUrl();
@@ -84,7 +83,16 @@ public class CodeReadyCheckIntelligenceCommandFromToolbarTest
   @Override
   protected void checkTestAppByPreviewUrlAndReturnToIde(String currentWindow) {
     String expectedText = "Welcome to JBoss AS 7!";
-    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
+    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
+        .until(
+            (ExpectedCondition<Boolean>)
+                driver ->
+                    clickOnPreviewUrlAndCheckTextIsPresentInPageBody(currentWindow, expectedText));
+  }
+
+  @Override
+  protected void checkTestAppByPreviewUrlAndReturnToIde(String currentWindow, String expectedText) {
+    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
         .until(
             (ExpectedCondition<Boolean>)
                 driver ->
@@ -94,7 +102,7 @@ public class CodeReadyCheckIntelligenceCommandFromToolbarTest
   @Override
   protected void checkTestAppByPreviewButtonAndReturnToIde(String currentWindow) {
     String expectedText = "Welcome to JBoss AS 7!";
-    new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
+    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
         .until(
             (ExpectedCondition<Boolean>)
                 driver ->

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyCommandsPaletteTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyCommandsPaletteTest.java
@@ -16,8 +16,13 @@ import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPEC
 
 import org.eclipse.che.selenium.intelligencecommand.CommandsPaletteTest;
 import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
+import org.testng.annotations.Test;
 
-/** @author Aleksandr Shmaraev */
+/**
+ * @author Aleksandr Shmaraev
+ *     <p>Note: test are being overrided in class to support proper sequence of tests (issue
+ *     CRW-155).
+ */
 public class CodeReadyCommandsPaletteTest extends CommandsPaletteTest {
 
   @Override
@@ -44,5 +49,17 @@ public class CodeReadyCommandsPaletteTest extends CommandsPaletteTest {
     commandsPalette.moveAndStartCommand(CommandsPalette.MoveTypes.DOWN, 2);
     consoles.waitTabNameProcessIsPresent(PROJECT_NAME + ": build");
     consoles.waitExpectedTextIntoConsole(BUILD_SUCCESS, EXPECTED_MESS_IN_CONSOLE_SEC);
+  }
+
+  @Test
+  @Override
+  public void commandPaletteTest() {
+    super.commandPaletteTest();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void newCommandTest() {
+    super.newCommandTest();
   }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyMacrosCommandsEditorTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyMacrosCommandsEditorTest.java
@@ -12,8 +12,13 @@
 package com.redhat.codeready.selenium.intelligencecommand;
 
 import org.eclipse.che.selenium.intelligencecommand.MacrosCommandsEditorTest;
+import org.testng.annotations.Test;
 
-/** @author Aleksandr Shmaraev */
+/**
+ * @author Aleksandr Shmaraev
+ *     <p>Note: test are being overrided in class to support proper sequence of tests (issue
+ *     CRW-155).
+ */
 public class CodeReadyMacrosCommandsEditorTest extends MacrosCommandsEditorTest {
 
   @Override
@@ -28,5 +33,17 @@ public class CodeReadyMacrosCommandsEditorTest extends MacrosCommandsEditorTest 
       "${server.wsagent/ws}"
     };
     return macrosItems;
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkCommandMacrosIntoCommandLine() {
+    super.checkCommandMacrosIntoCommandLine();
+  }
+
+  @Test(priority = 2)
+  @Override
+  public void checkCommandMacrosIntoPreviewUrl() {
+    super.checkCommandMacrosIntoPreviewUrl();
   }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/languageserver/CodeReadyGolangFileEditingTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/languageserver/CodeReadyGolangFileEditingTest.java
@@ -12,13 +12,83 @@
 package com.redhat.codeready.selenium.languageserver;
 
 import org.eclipse.che.selenium.languageserver.GolangFileEditingTest;
+import org.testng.annotations.Test;
 
-/** @author Aleksandr Shmaraev */
+/**
+ * @author Aleksandr Shmaraev
+ *     <p>Note: test are being overrided in class to support proper sequence of tests (issue
+ *     CRW-155).
+ */
 public class CodeReadyGolangFileEditingTest extends GolangFileEditingTest {
 
   @Override
   protected void waitExpectedTextIntoConsole() {
     consoles.waitExpectedTextIntoConsole("Finished running tool:");
     consoles.waitExpectedTextIntoConsole("/usr/bin/go build");
+  }
+
+  @Test
+  @Override
+  public void checkLanguageServerInitialized() {
+    super.checkLanguageServerInitialized();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkAutocompleteFeature() {
+    super.checkAutocompleteFeature();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkCodeValidationFeature() {
+    super.checkCodeValidationFeature();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkFormatCodeFeature() {
+    super.checkFormatCodeFeature();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkFindDefinitionFeature() {
+    super.checkFindDefinitionFeature();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkFindReferencesFeature() {
+    super.checkFindReferencesFeature();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkSignatureHelpFeature() {
+    super.checkSignatureHelpFeature();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkGoToSymbolFeature() {
+    super.checkGoToSymbolFeature();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkFindProjectSymbolFeature() {
+    super.checkFindProjectSymbolFeature();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkHoverFeature() {
+    super.checkHoverFeature();
+  }
+
+  @Test(priority = 2)
+  public void checkRenameFeature() {
+    super.checkRenameFeature();
   }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/languageserver/CodeReadyJsonFileEditingTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/languageserver/CodeReadyJsonFileEditingTest.java
@@ -1,8 +1,13 @@
 package com.redhat.codeready.selenium.languageserver;
 
 import org.eclipse.che.selenium.languageserver.JsonFileEditingTest;
+import org.testng.annotations.Test;
 
-/** @author Aleksandr Shmaraev */
+/**
+ * @author Aleksandr Shmaraev
+ *     <p>Note: test are being overrided in class to support proper sequence of tests (issue
+ *     CRW-155).
+ */
 public class CodeReadyJsonFileEditingTest extends JsonFileEditingTest {
 
   private static final String PROJECT_NAME = "web-nodejs-simple";
@@ -10,5 +15,35 @@ public class CodeReadyJsonFileEditingTest extends JsonFileEditingTest {
   @Override
   protected void selectSampleProject() {
     wizard.selectSample(PROJECT_NAME);
+  }
+
+  @Test
+  @Override
+  public void checkLanguageServerInitialized() {
+    super.checkLanguageServerInitialized();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkCodeValidationFeature() {
+    super.checkCodeValidationFeature();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkAutocompleteFeature() {
+    super.checkAutocompleteFeature();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkHoverFeature() {
+    super.checkHoverFeature();
+  }
+
+  @Test(priority = 2)
+  @Override
+  public void checkGoToSymbolFeature() {
+    super.checkGoToSymbolFeature();
   }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/CodeReadyWorkingWithSplitPanelTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/CodeReadyWorkingWithSplitPanelTest.java
@@ -12,8 +12,13 @@
 package com.redhat.codeready.selenium.miscellaneous;
 
 import org.eclipse.che.selenium.miscellaneous.WorkingWithSplitPanelTest;
+import org.testng.annotations.Test;
 
-/** @author Aleksandr Shmaraev */
+/**
+ * @author Aleksandr Shmaraev
+ *     <p>Note: test are being overrided in class to support proper sequence of tests (issue
+ *     CRW-155).
+ */
 public class CodeReadyWorkingWithSplitPanelTest extends WorkingWithSplitPanelTest {
 
   @Override
@@ -23,4 +28,28 @@ public class CodeReadyWorkingWithSplitPanelTest extends WorkingWithSplitPanelTes
 
   @Override
   protected void checkExpectedTextIsPresent() {}
+
+  @Test
+  @Override
+  public void checkMultiSplitPane() {
+    super.checkMultiSplitPane();
+  }
+
+  @Test(priority = 1)
+  @Override
+  public void checkTerminalAndBuild() {
+    super.checkTerminalAndBuild();
+  }
+
+  @Test(priority = 2)
+  @Override
+  public void checkTabsOnSplitPanel() {
+    super.checkTabsOnSplitPanel();
+  }
+
+  @Test(priority = 3)
+  @Override
+  public void checkSwitchingTabsAndPanels() {
+    super.checkSwitchingTabsAndPanels();
+  }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/DotNetUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/DotNetUserStoryTest.java
@@ -113,12 +113,13 @@ public class DotNetUserStoryTest extends AbstractUserStoryTest {
   }
 
   private void checkAutocompleteFeature() {
-    editor.deleteCurrentLineAndInsertNew();
+    editor.deleteCurrentLine();
 
     editor.goToCursorPositionVisible(23, 49);
     editor.typeTextIntoEditor(".");
     editor.launchAutocomplete();
     editor.enterAutocompleteProposal("Build ");
+    editor.waitTextIntoEditor("Build");
     editor.typeTextIntoEditor("();");
     editor.waitTextIntoEditor("Build();");
     editor.waitAllMarkersInvisibility(ERROR, LOADER_TIMEOUT_SEC);


### PR DESCRIPTION
* Set the test methods of e2e tests explicitly related the known issue (https://issues.jboss.org/browse/CRW-155)
* Correct the 'user-story' e2e test to increase reliability