### PR TITLE
Selenium: fix selenium tests from dashboard package

### DIFF
--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -12,6 +12,7 @@
 package com.redhat.codeready.selenium.dashboard;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.UPDATING_PROJECT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.WorkspaceDetailsTab.PROJECTS;
@@ -112,7 +113,7 @@ public class CreateAndDeleteProjectsTest {
     explorer.waitItem(KITCHENSINK_EXAMPLE);
     explorer.waitItem(SECOND_KINTCHENSINK_PROJECT_NAME);
     notificationsPopupPanel.waitPopupPanelsAreClosed();
-    mavenPluginStatusBar.waitClosingInfoPanel();
+    mavenPluginStatusBar.waitClosingInfoPanel(UPDATING_PROJECT_TIMEOUT_SEC);
     explorer.waitDefinedTypeOfFolder(KITCHENSINK_EXAMPLE, PROJECT_FOLDER);
     notificationsPopupPanel.waitPopupPanelsAreClosed();
   }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/StacksListTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/StacksListTest.java
@@ -78,7 +78,7 @@ public class StacksListTest {
     // check Java 1.8 stack info
     assertTrue(stacks.isStackItemExisted("Java 1.8"));
     assertEquals(
-        stacks.getStackDescription("Java 1.8"), "Default Java Stack with OpenJDK 1.8, Maven 3.5");
+        stacks.getStackDescription("Java 1.8"), "RHEL 7 Java stack with OpenJDK 1.8 and Maven 3.5");
 
     String stackComponents = stacks.getStackComponents("Java 1.8");
     componentList.forEach(
@@ -175,6 +175,7 @@ public class StacksListTest {
 
     dashboard.selectStacksItemOnDashboard();
     stacks.waitToolbarTitleName();
+    stacks.waitStackItem(stack);
     stacks.clickOnDuplicateStackButton(stack);
 
     for (String name : stacks.getStacksNamesList()) {

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/NewWorkspacePageTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/NewWorkspacePageTest.java
@@ -58,7 +58,8 @@ public class NewWorkspacePageTest {
           CodereadyStacks.GO,
           CodereadyStacks.NODE,
           CodereadyStacks.PHP,
-          CodereadyStacks.PYTHON);
+          CodereadyStacks.PYTHON,
+          CodereadyStacks.JAVA_RHEL8);
 
   private static final List<CodereadyNewWorkspace.CodereadyStacks>
       EXPECTED_CODEREADY_QUICK_START_STACKS_REVERSE_ORDER =
@@ -69,6 +70,7 @@ public class NewWorkspacePageTest {
               CodereadyStacks.SPRING_BOOT,
               CodereadyStacks.WILD_FLY_SWARM,
               CodereadyStacks.FUSE,
+              CodereadyStacks.JAVA_RHEL8,
               CodereadyStacks.PYTHON,
               CodereadyStacks.PHP,
               CodereadyStacks.NODE,
@@ -90,14 +92,16 @@ public class NewWorkspacePageTest {
               CodereadyStacks.GO,
               CodereadyStacks.NODE,
               CodereadyStacks.PHP,
-              CodereadyStacks.PYTHON);
+              CodereadyStacks.PYTHON,
+              CodereadyStacks.JAVA_RHEL8);
 
   private static final List<CodereadyNewWorkspace.CodereadyStacks> EXPECTED_CODEREADY_JAVA_STACKS =
       asList(
           CodereadyStacks.WILD_FLY_SWARM,
           CodereadyStacks.SPRING_BOOT,
           CodereadyStacks.JAVA_EAP,
-          CodereadyStacks.JAVA_DEFAULT);
+          CodereadyStacks.JAVA_DEFAULT,
+          CodereadyStacks.JAVA_RHEL8);
 
   private static final List<String> EXPECTED_CODEREADY_FILTERS_SUGGESTIONS =
       asList(MAVEN_SUGGESTION_TITLE);

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/WorkspacesListTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/WorkspacesListTest.java
@@ -38,6 +38,7 @@ import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceOvervie
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceProjects;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces.Status;
+import org.openqa.selenium.By;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -366,6 +367,8 @@ public class WorkspacesListTest {
 
   @Test(priority = 1, alwaysRun = true)
   public void checkDocumentionLink() {
+    String documentPageTitleXpath = "//h1[contains(text(),'Administering workspaces')]";
+
     workspaces.waitPageLoading();
     String mainWindow = seleniumWebDriver.getWindowHandle();
 
@@ -374,7 +377,7 @@ public class WorkspacesListTest {
     seleniumWebDriverHelper.waitOpenedSomeWin();
     seleniumWebDriverHelper.switchToNextWindow(mainWindow);
 
-    assertEquals(EXPECTED_DOCUMENTATION_PAGE_TITLE, documentationPage.getTitle());
+    seleniumWebDriverHelper.waitVisibility(By.xpath(documentPageTitleXpath));
 
     seleniumWebDriver.close();
     seleniumWebDriver.switchTo().window(mainWindow);

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/details/WorkspaceDetailsMachineActionsTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/details/WorkspaceDetailsMachineActionsTest.java
@@ -47,7 +47,7 @@ public class WorkspaceDetailsMachineActionsTest {
   private static final String SPECIAL_CHARACTERS_ERRORS_MESSAGE =
       "The name should not contain special characters like space, dollar, etc.";
   private static final String NAME_WITH_SPECIAL_CHARACTERS = "@#$^&*(!";
-  private static final String MAX_VALID_NAME = generate("max_name", 120);
+  private static final String MAX_VALID_NAME = generate("max-name", 120);
   private static final String TOO_BIG_NAME = generate(MAX_VALID_NAME, 1);
   private static final String TOO_BIG_RAM_SIZE = "1000";
   private static final String MAX_VALID_RAM_VALUE = "100";


### PR DESCRIPTION
This PR:
- increase timeout for checking that Maven plugin status bar is closed(```CreateAndDeleteProjectsTest```);
- update expected stack description for **Java 1.8** stack(```StacksListTest```);
- update expected stacks list on **New Workspaces** page(```NewWorkspacePageTest```);
- fix expected page title on **Codeready** document web page(```WorkspacesListTest```);
- fix machine name generation(not use ```_``` symbol) in ```WorkspaceDetailsMachineActionsTest```.