### PR TITLE
Test E2E: Adapt the 'user-story' e2e tests to CRW deployed to OCP 4.0

### DIFF
--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
@@ -76,7 +76,8 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
       PROJECT + "/src/main/java/org/jboss/as/quickstarts/kitchensinkjsp/data";
 
   private static final String PATH_TO_CONTROLLER_PACKAGE =
-      PROJECT + "/src/main/java/org/jboss/as/quickstarts/kitchensinkjsp/controller";
+      PROJECT
+          + "/src/main/java/org/jboss/as/quickstarts/kitchensinkjsp/controller/MemberRegistration.java";
 
   private static final String[] REPORT_DEPENDENCY_ANALYSIS = {
     "Report for /projects/kitchensink-example/pom.xml",
@@ -208,6 +209,7 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
             "getName() : String Member",
             "Name - java.util.jar.Attributes");
 
+    seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
     projectExplorer.scrollAndSelectItem(PROJECT);
     checkGoToDeclarationFeature();
     checkFindUsagesFeature();
@@ -245,7 +247,7 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
     final String expectedErrorMarkerText =
         "Application dependency commons-fileupload:commons-fileupload-1.3 is vulnerable: CVE-2014-0050 CVE-2016-3092 CVE-2016-1000031 CVE-2013-2186. Recommendation: use version 1.3.3";
 
-    // open file
+    // update file
     seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
     projectExplorer.waitItem(PROJECT);
     String pomFileChangedText =
@@ -253,6 +255,14 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
     projectServiceClient.updateFile(testWorkspace.getId(), pomXmlFilePath, pomFileChangedText);
     projectExplorer.scrollAndSelectItem(pomXmlFilePath);
     projectExplorer.waitItemIsSelected(pomXmlFilePath);
+    projectExplorer.openItemByPath(pomXmlFilePath);
+    editor.waitActive();
+    editor.closeAllTabs();
+    consoles.selectProcessByTabName("dev-machine");
+    consoles.waitExpectedTextIntoConsole("updating projectconfig for /kitchensink-example");
+    editor.closeAllTabs();
+
+    // open file
     projectExplorer.openItemByPath(pomXmlFilePath);
     editor.waitTabIsPresent(pomXmlEditorTabTitle, LOADER_TIMEOUT_SEC);
     editor.waitTabSelection(0, pomXmlEditorTabTitle);
@@ -321,8 +331,8 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
   }
 
   private void checkGoToDeclarationFeature() {
+    projectExplorer.quickRevealToItemWithJavaScript(PATH_TO_CONTROLLER_PACKAGE);
     projectExplorer.openItemByPath(PATH_TO_CONTROLLER_PACKAGE);
-    projectExplorer.openItemByVisibleNameInExplorer("MemberRegistration.java");
     editor.waitActive();
     editor.goToPosition(34, 14);
     editor.typeTextIntoEditor(F4.toString());

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
@@ -257,7 +257,6 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
     projectExplorer.waitItemIsSelected(pomXmlFilePath);
     projectExplorer.openItemByPath(pomXmlFilePath);
     editor.waitActive();
-    editor.closeAllTabs();
     consoles.selectProcessByTabName("dev-machine");
     consoles.waitExpectedTextIntoConsole("updating projectconfig for /kitchensink-example");
     editor.closeAllTabs();

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/RedHatFuseUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/RedHatFuseUserStoryTest.java
@@ -134,7 +134,9 @@ public class RedHatFuseUserStoryTest extends AbstractUserStoryTest {
   }
 
   private void checkCodeValidationFeature() {
-    editor.selectTabByName("Application");
+    editor.closeAllTabs();
+    projectExplorer.openItemByPath(PATH_TO_MAIN_PACKAGE + "/Application.java");
+    editor.waitActive();
     editor.goToPosition(32, 27);
     editor.typeTextIntoEditor("r");
     editor.waitMarkerInPosition(ERROR, 32);

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/SpringBootUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/SpringBootUserStoryTest.java
@@ -147,7 +147,9 @@ public class SpringBootUserStoryTest extends AbstractUserStoryTest {
   }
 
   private void checkCodeValidationFeature() {
-    editor.selectTabByName("Greeting");
+    editor.closeAllTabs();
+    projectExplorer.openItemByPath(PATH_TO_MAIN_PACKAGE + "/service/Greeting.java");
+    editor.waitActive();
     editor.goToPosition(34, 17);
     editor.typeTextIntoEditor("p");
     editor.waitMarkerInPosition(ERROR, 34);


### PR DESCRIPTION
* Add corrections to the selenium tests _user-story_  to adapt for CRW deployed to OCP 4.0
* Related known issue: https://issues.jboss.org/browse/CRW-148