### PR TITLE
Get rid of 'for-openshift' in docs and help path

### DIFF
--- a/assembly/assembly-dashboard-war/src/main/webapp/assets/branding/product.json.template
+++ b/assembly/assembly-dashboard-war/src/main/webapp/assets/branding/product.json.template
@@ -7,7 +7,7 @@
   "loader": "CodeReady_icon_loader.svg",
   "ideResources": "/_app/",
   "websocketContext": "/api/websocket",
-  "helpPath": "https://access.redhat.com/products/red-hat-codeready-workspaces-for-openshift/",
+  "helpPath": "https://access.redhat.com/products/red-hat-codeready-workspaces/",
   "helpTitle": "Support",
   "supportEmail": "codeready-workspaces-wish@redhat.com",
   "oauthDocs": "Configure GitHub OAuth in RH SSO realm settings",

--- a/ide/codeready-product-info/src/main/resources/com/redhat/codeready/plugin/product/info/client/CodeReadyLocalizationConstant.properties
+++ b/ide/codeready-product-info/src/main/resources/com/redhat/codeready/plugin/product/info/client/CodeReadyLocalizationConstant.properties
@@ -12,6 +12,6 @@
 
 codeready.tab.title=CodeReady Workspaces
 codeready.tab.title.with.workspace.name=CodeReady Workspaces | {0}
-get.support.link=https://access.redhat.com/products/red-hat-codeready-workspaces-for-openshift/
+get.support.link=https://access.redhat.com/products/red-hat-codeready-workspaces/
 get.product.name=CodeReady Workspaces
 support.title=Support


### PR DESCRIPTION
This PR fixes outdated links in CRW to product page of "Codeready Workspaces for Openshift": https://access.redhat.com/products/red-hat-codeready-workspaces-for-openshift/

Signed-off-by: Dmytro Nochevnov <dnochevn@redhat.com>