### PR TITLE
add -P native when building che in Jenkins,...

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,7 +182,7 @@ timeout(180) {
 			cat che/dashboard/src/assets/branding/branding.css
 		'''
 
-		sh "mvn clean install ${MVN_FLAGS} -f ${CHE_path}/pom.xml ${MVN_EXTRA_FLAGS}"
+		sh "mvn clean install ${MVN_FLAGS} -P native -f ${CHE_path}/pom.xml ${MVN_EXTRA_FLAGS}"
 		stash name: 'stashChe', includes: findFiles(glob: '.repository/**').join(", ")
 		archiveArtifacts fingerprint: false, artifacts:"**/*.log, **/${CHE_path}/pom.xml, **/${CHE_path}/assembly/assembly-main/pom.xml, **/${CHE_path}/assembly/assembly-main/src/assembly/assembly.xml"
 


### PR DESCRIPTION
add -P native when building che in Jenkins, since we might need that now that we're using docker-ce 18.09 instead of docker 1.13

Change-Id: I873906e15fea8aee46bed69673f1e958618041b7
Signed-off-by: nickboldt <nboldt@redhat.com>