### PR TITLE
Fix year to 2019, EPL v1 to v2 in copyright header

### DIFF
--- a/assembly/assembly-dashboard-war/src/assembly/assembly.xml
+++ b/assembly/assembly-dashboard-war/src/assembly/assembly.xml
@@ -1,9 +1,9 @@
 <!--
 
-    Copyright (c) 2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
 
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/assembly/assembly-dashboard-war/src/main/webapp/assets/branding/DEPRECATED/branding.css
+++ b/assembly/assembly-dashboard-war/src/main/webapp/assets/branding/DEPRECATED/branding.css
@@ -1,8 +1,8 @@
 /**
- * Copyright (c) 2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
 
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *

--- a/assembly/assembly-dashboard-war/src/main/webapp/assets/branding/DEPRECATED/redhat-logo.svg
+++ b/assembly/assembly-dashboard-war/src/main/webapp/assets/branding/DEPRECATED/redhat-logo.svg
@@ -1,10 +1,10 @@
 ?xml version="1.0" encoding="utf-8"?>
 <!--
 
-    Copyright (c) 2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
 
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/assembly/assembly-wsagent-server/src/assembly/assembly.xml
+++ b/assembly/assembly-wsagent-server/src/assembly/assembly.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016-2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/assembly/codeready-ide-gwt-app/src/main/module.gwt.xml
+++ b/assembly/codeready-ide-gwt-app/src/main/module.gwt.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016-2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/assembly/codeready-workspaces-assembly-main/src/assembly/assembly.xml
+++ b/assembly/codeready-workspaces-assembly-main/src/assembly/assembly.xml
@@ -1,8 +1,8 @@
 <!--
 
-    Copyright (c) 2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# Copyright (c) 2018 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 
 # All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
+# are made available under the terms of the Eclipse Public License v2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #

--- a/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-cpp.svg
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-cpp.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2012-2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-dotnet.svg
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-dotnet.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2012-2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-go.svg
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-go.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 
-    Copyright (c) 2012-2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-java.svg
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-java.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2012-2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-node.svg
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-node.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2012-2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-php.svg
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-php.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2012-2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-python.svg
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-python.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" ?>
 <!--
 
-    Copyright (c) 2012-2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-spring-boot.svg
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-spring-boot.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/ide/codeready-product-info/src/main/java/com/redhat/codeready/plugin/product/info/client/CodeReadyLocalizationConstant.java
+++ b/ide/codeready-product-info/src/main/java/com/redhat/codeready/plugin/product/info/client/CodeReadyLocalizationConstant.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/ide/codeready-product-info/src/main/java/com/redhat/codeready/plugin/product/info/client/CodeReadyProductInfoDataProvider.java
+++ b/ide/codeready-product-info/src/main/java/com/redhat/codeready/plugin/product/info/client/CodeReadyProductInfoDataProvider.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2012-2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *

--- a/ide/codeready-product-info/src/main/java/com/redhat/codeready/plugin/product/info/client/CodeReadyResources.java
+++ b/ide/codeready-product-info/src/main/java/com/redhat/codeready/plugin/product/info/client/CodeReadyResources.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2012-2019 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *

--- a/ide/codeready-product-info/src/main/java/com/redhat/codeready/plugin/product/info/client/inject/ProductInfoGinModule.java
+++ b/ide/codeready-product-info/src/main/java/com/redhat/codeready/plugin/product/info/client/inject/ProductInfoGinModule.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2012-2017 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *

--- a/ide/codeready-product-info/src/main/resources/com/redhat/codeready/plugin/product/info/client/CodeReadyLocalizationConstant.properties
+++ b/ide/codeready-product-info/src/main/resources/com/redhat/codeready/plugin/product/info/client/CodeReadyLocalizationConstant.properties
@@ -1,8 +1,8 @@
 #
-# Copyright (c) 2018 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 #
 # All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
+# are made available under the terms of the Eclipse Public License v2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #

--- a/plugins/che-plugin-bayesian-lang-server/src/main/java/org/eclipse/che/plugin/languageserver/bayesian/BayesianLanguageServerModule.java
+++ b/plugins/che-plugin-bayesian-lang-server/src/main/java/org/eclipse/che/plugin/languageserver/bayesian/BayesianLanguageServerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/plugins/che-plugin-bayesian-lang-server/src/main/java/org/eclipse/che/plugin/languageserver/bayesian/server/launcher/BayesianLanguageServerConfig.java
+++ b/plugins/che-plugin-bayesian-lang-server/src/main/java/org/eclipse/che/plugin/languageserver/bayesian/server/launcher/BayesianLanguageServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/plugins/che-plugin-bayesian-lang-server/src/test/resources/log4j.xml
+++ b/plugins/che-plugin-bayesian-lang-server/src/test/resources/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016-2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/test/codeready-test-e2e/e2e-tests.sh
+++ b/test/codeready-test-e2e/e2e-tests.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# Copyright (c) 2018 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 #
 # All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
+# are made available under the terms of the Eclipse Public License v2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/core/CodereadySeleniumSuiteModule.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/core/CodereadySeleniumSuiteModule.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/core/CodereadySeleniumTestHandler.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/core/CodereadySeleniumTestHandler.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/core/client/keycloak/cli/CodeReadyOpenShiftKeycloakCliCommandExecutor.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/core/client/keycloak/cli/CodeReadyOpenShiftKeycloakCliCommandExecutor.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/core/executor/hotupdate/CodeReadyHotUpdateUtil.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/core/executor/hotupdate/CodeReadyHotUpdateUtil.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/CodereadyDebuggerPanel.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/CodereadyDebuggerPanel.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/CodereadyEditor.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/CodereadyEditor.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/account/CodeReadyKeycloakFederatedIdentitiesPage.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/account/CodeReadyKeycloakFederatedIdentitiesPage.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/account/CodereadyKeycloakHeaderButtons.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/account/CodereadyKeycloakHeaderButtons.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/dashboard/CodeReadyCreateWorkspaceHelper.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/dashboard/CodeReadyCreateWorkspaceHelper.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/dashboard/CodereadyFindUsageWidget.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/dashboard/CodereadyFindUsageWidget.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/dashboard/CodereadyNewWorkspace.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/dashboard/CodereadyNewWorkspace.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/CreateFactoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/CreateFactoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/CreateStackTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/CreateStackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/CreateWorkspaceTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/CreateWorkspaceTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/StacksListTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/StacksListTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/organization/ShareWorkspaceMemberTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/organization/ShareWorkspaceMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/organization/ShareWorkspaceOwnerTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/organization/ShareWorkspaceOwnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/AddOrImportProjectFormTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/AddOrImportProjectFormTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/NewWorkspacePageTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/NewWorkspacePageTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/WorkspacesListTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/WorkspacesListTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/details/WorkspaceDetailsMachineActionsTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/details/WorkspaceDetailsMachineActionsTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/details/WorkspaceDetailsMachinesRamTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/details/WorkspaceDetailsMachinesRamTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/details/WorkspaceDetailsOverviewTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/details/WorkspaceDetailsOverviewTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/details/WorkspaceDetailsProjectsTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/details/WorkspaceDetailsProjectsTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/details/WorkspaceDetailsSingleMachineTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/dashboard/workspaces/details/WorkspaceDetailsSingleMachineTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyCppProjectDebuggingTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyCppProjectDebuggingTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyPhpProjectDebuggingTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyPhpProjectDebuggingTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyStepIntoStepOverStepReturnWithChangeVariableTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/debugger/CodeReadyStepIntoStepOverStepReturnWithChangeVariableTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/CodeReadySplitEditorFeatureTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/CodeReadySplitEditorFeatureTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/autocomplete/CodeReadyAutocompleteProposalJavaDocTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/editor/autocomplete/CodeReadyAutocompleteProposalJavaDocTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/factory/CodeReadyCheckOpenFileFeatureTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/factory/CodeReadyCheckOpenFileFeatureTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/factory/CodeReadyCheckRunCommandFeatureTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/factory/CodeReadyCheckRunCommandFeatureTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/factory/CodeReadyCreateNamedFactoryFromDashboardTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/factory/CodeReadyCreateNamedFactoryFromDashboardTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/git/AuthorizeOnGithubFromDashboardTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/git/AuthorizeOnGithubFromDashboardTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/git/AuthorizeOnGithubFromPreferencesTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/git/AuthorizeOnGithubFromPreferencesTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/git/ImportWizardFormTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/git/ImportWizardFormTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyAutocompleteCommandsEditorTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyAutocompleteCommandsEditorTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyCheckIntelligenceCommandFromToolbarTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyCheckIntelligenceCommandFromToolbarTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyCommandsPaletteTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyCommandsPaletteTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyMacrosCommandsEditorTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/intelligencecommand/CodeReadyMacrosCommandsEditorTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/languageserver/CodeReadyGolangFileEditingTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/languageserver/CodeReadyGolangFileEditingTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/languageserver/csharp/CodeReadyCSharpFileEditingTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/languageserver/csharp/CodeReadyCSharpFileEditingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/languageserver/php/CodeReadyPhpFileEditingTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/languageserver/php/CodeReadyPhpFileEditingTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/CodeReadyFindTextFeatureTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/CodeReadyFindTextFeatureTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/CodeReadyOpenInTerminalTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/CodeReadyOpenInTerminalTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/CodeReadyResolveDependencyAfterRecreateProjectTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/CodeReadyResolveDependencyAfterRecreateProjectTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/CodeReadyWorkingWithSplitPanelTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/CodeReadyWorkingWithSplitPanelTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/MachinesAsynchronousStartTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/miscellaneous/MachinesAsynchronousStartTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/projectexplorer/CodeReadyCheckShowHideHiddenFilesTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/projectexplorer/CodeReadyCheckShowHideHiddenFilesTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/AbstractUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/AbstractUserStoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/ClangCppUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/ClangCppUserStoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/DotNetUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/DotNetUserStoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/GoUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/GoUserStoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaEapUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaEapUserStoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaRhel8UserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaRhel8UserStoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/NodeJsUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/NodeJsUserStoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/PhpUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/PhpUserStoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/PythonUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/PythonUserStoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/RedHatFuseUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/RedHatFuseUserStoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/SpringBootUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/SpringBootUserStoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/VertxUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/VertxUserStoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/WildFlyUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/WildFlyUserStoryTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/workspaces/CodeReadyCreateWorkspaceOnDashboardTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/workspaces/CodeReadyCreateWorkspaceOnDashboardTest.java
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2018 Red Hat, Inc.
+* Copyright (c) 2019 Red Hat, Inc.
 
 * All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
+* are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
 * http://www.eclipse.org/legal/epl-v10.html
 *

--- a/test/codeready-test-e2e/src/test/resources/conf/selenium.properties
+++ b/test/codeready-test-e2e/src/test/resources/conf/selenium.properties
@@ -1,8 +1,8 @@
 #
-# Copyright (c) 2018 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 #
 # All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
+# are made available under the terms of the Eclipse Public License v2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #

--- a/test/codeready-test-e2e/src/test/resources/logback-test.xml
+++ b/test/codeready-test-e2e/src/test/resources/logback-test.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
 
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/test/codeready-test-e2e/src/test/resources/logging.properties
+++ b/test/codeready-test-e2e/src/test/resources/logging.properties
@@ -1,8 +1,8 @@
 #
-# Copyright (c) 2018 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 #
 # All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
+# are made available under the terms of the Eclipse Public License v2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #

--- a/test/codeready-test-e2e/src/test/resources/projects/Decorator.java
+++ b/test/codeready-test-e2e/src/test/resources/projects/Decorator.java
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
 
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *

--- a/test/codeready-test-e2e/src/test/resources/suites/CheOneThreadTestsSuite.xml
+++ b/test/codeready-test-e2e/src/test/resources/suites/CheOneThreadTestsSuite.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2012-2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/test/codeready-test-e2e/src/test/resources/suites/CheSuite.xml
+++ b/test/codeready-test-e2e/src/test/resources/suites/CheSuite.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2012-2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/test/codeready-test-e2e/src/test/resources/suites/CodereadyOneThreadTestsSuite.xml
+++ b/test/codeready-test-e2e/src/test/resources/suites/CodereadyOneThreadTestsSuite.xml
@@ -1,9 +1,9 @@
 <!--
 
-    Copyright (c) 2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
 
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/test/codeready-test-e2e/src/test/resources/suites/CodereadySmokeSuite.xml
+++ b/test/codeready-test-e2e/src/test/resources/suites/CodereadySmokeSuite.xml
@@ -1,9 +1,9 @@
 <!--
 
-    Copyright (c) 2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
 
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 

--- a/test/codeready-test-e2e/src/test/resources/suites/CodereadySuite.xml
+++ b/test/codeready-test-e2e/src/test/resources/suites/CodereadySuite.xml
@@ -1,9 +1,9 @@
 <!--
 
-    Copyright (c) 2018 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
 
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License v2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 


### PR DESCRIPTION
Fix copyright header to have:
- `Copyright (c) 2019 Red Hat, Inc.`
- `Eclipse Public License v2.0`

Signed-off-by: Dmytro Nochevnov <dnochevn@redhat.com>