### PR TITLE
Test E2E: Correct the 'JavaUserStoryTest' to increase reliability

### DIFF
--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/JavaUserStoryTest.java
@@ -245,7 +245,7 @@ public class JavaUserStoryTest extends AbstractUserStoryTest {
     final String pomXmlEditorTabTitle = "jboss-as-kitchensink";
 
     final String expectedErrorMarkerText =
-        "Application dependency commons-fileupload:commons-fileupload-1.3 is vulnerable: CVE-2014-0050 CVE-2016-3092 CVE-2016-1000031 CVE-2013-2186. Recommendation: use version 1.3.3";
+        "Application dependency commons-fileupload:commons-fileupload-1.3 is vulnerable: CVE-2014-0050 CVE-2016-3092 CVE-2016-1000031 CVE-2013-2186. Recommendation: use version";
 
     // update file
     seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/NodeJsUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/NodeJsUserStoryTest.java
@@ -103,7 +103,7 @@ public class NodeJsUserStoryTest extends AbstractUserStoryTest {
     final String fileName = "package.json";
     final String packageJsonFilePath = PROJECT + "/" + fileName;
     final String expectedErrorMarkerText =
-        "Application dependency serve-static-1.7.1 is vulnerable: CVE-2015-1164. Recommendation: use version 1.7.2";
+        "Application dependency serve-static-1.7.1 is vulnerable: CVE-2015-1164. Recommendation: use version";
 
     // open file
     projectExplorer.waitItem(PROJECT);


### PR DESCRIPTION
* Correct the _JavaUserStoryTest_ to make independent from changes of CVE recommended versions when checking the error marker of Bayesian language server
* Related e2e tests: _JavaUserStoryTest_, _JBossEapUserStoryTest_