### PR TITLE
Fix build of Eclipse Che 6.19.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,6 +177,8 @@ timeout(180) {
 		unstash 'stashLSJ'
 		installNPM()
 		installGo()
+		sh "sed -i 's@executable=\"npm\"@executable=\"yarn\"@' ${CHE_path}/workspace-loader/pom.xml"
+		sh "cat ${CHE_path}/workspace-loader/pom.xml"
 		buildMaven()
 		// patch - switch che-ls-jdt version to a different one
 		// sh "sed -i -e \"s#\\(.*<che.ls.jdt.version>\\)0.0.3\\(</che.ls.jdt.version>.*\\)#\\10.0.4-SNAPSHOT\\2#\" ${CHE_path}/pom.xml"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -178,7 +178,6 @@ timeout(180) {
 		installNPM()
 		installGo()
 		sh "sed -i 's@executable=\"npm\"@executable=\"yarn\"@' ${CHE_path}/workspace-loader/pom.xml"
-		sh "cat ${CHE_path}/workspace-loader/pom.xml"
 		buildMaven()
 		// patch - switch che-ls-jdt version to a different one
 		// sh "sed -i -e \"s#\\(.*<che.ls.jdt.version>\\)0.0.3\\(</che.ls.jdt.version>.*\\)#\\10.0.4-SNAPSHOT\\2#\" ${CHE_path}/pom.xml"


### PR DESCRIPTION
Its' workaround suggested by @eivantsov to fix the build of Eclipse Che 6.19.3:
```
[INFO] Che Workspace Loader :: Web App .................... FAILURE [ 30.267 s]
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.8:run (build-workspace-loader) on project che-workspace-loader: An Ant BuildException has occured: exec returned: 2
[ERROR] around Ant part ...<exec failonerror="true" dir="/mnt/hudson_workspace/workspace/crw_stable-branch/che/workspace-loader" executable="npm">... @ 7:122 in /mnt/hudson_workspace/workspace/crw_stable-branch/che/workspace-loader/target/antrun/build-main.xml
[ERROR] -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.8:run (build-workspace-loader) on project che-workspace-loader: An Ant BuildException has occured: exec returned: 2
around Ant part ...<exec failonerror="true" dir="/mnt/hudson_workspace/workspace/crw_stable-branch/che/workspace-loader" executable="npm">... @ 7:122 in /mnt/hudson_workspace/workspace/crw_stable-branch/che/workspace-loader/target/antrun/build-main.xml
...
```

Signed-off-by: Dmytro Nochevnov <dnochevn@redhat.com>