### PR TITLE
Fix Node10UserStoryTest.java

### DIFF
--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/Node10UserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/Node10UserStoryTest.java
@@ -16,6 +16,7 @@ import static com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWor
 import com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWorkspace;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import org.testng.annotations.Test;
 
 public class Node10UserStoryTest extends Node8UserStoryTest {
   public Node10UserStoryTest() throws IOException, URISyntaxException {
@@ -25,5 +26,25 @@ public class Node10UserStoryTest extends Node8UserStoryTest {
   @Override
   protected CodereadyNewWorkspace.CodereadyStacks getStackName() {
     return NODE10;
+  }
+
+  @Test
+  public void createWorkspaceFromDashboard() throws Exception {
+    super.createWorkspaceFromDashboard();
+  }
+
+  @Test(priority = 1)
+  public void runAndCheckNodeJsApp() throws Exception {
+    super.runAndCheckNodeJsApp();
+  }
+
+  @Test(priority = 2)
+  public void checkMainLsFeatures() {
+    super.checkMainLsFeatures();
+  }
+
+  @Test(priority = 3)
+  public void checkBayesianLsErrorMarker() throws Exception {
+    super.checkBayesianLsErrorMarker();
   }
 }


### PR DESCRIPTION
Fixup of regression in e2e user stories tests: blank pages in https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/pre-release/view/OCP%203.11/job/pre-release-user-stories-e2e-tests-against-OCP/114/E2E_20tests_20report/failsafe-report.html#com.redhat.codeready.selenium.userstory.Node10UserStoryTest 

Signed-off-by: Dmytro Nochevnov <dnochevn@redhat.com>