### PR TITLE
Test E2E: Correct the 'id selector' related to last change on the dashboard

### DIFF
--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/dashboard/CodereadyNewWorkspace.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/dashboard/CodereadyNewWorkspace.java
@@ -80,7 +80,7 @@ public class CodereadyNewWorkspace extends NewWorkspace {
     NODE10("node10-default"),
     PHP("php-default"),
     PYTHON("python-default"),
-    JAVA_RHEL8("rhel8-default");
+    JAVA_RHEL8("java-rhel8-default");
 
     private final String id;
 


### PR DESCRIPTION
* Correct the 'id selector' in the _CodereadyNewWorkspace_ related to the last change on dashboard
* Related e2e test:  _JavaRhel8UserStoryTest_