### PR TITLE
add EAP to JDK 8 stack image (DO NOT MERGE...

### DIFF
--- a/ide/codeready-ide-stacks/src/main/resources/stacks.json
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks.json
@@ -3,9 +3,10 @@
     "id": "java-rhel8-default",
     "creator": "ide",
     "name": "Java 1.8 on RHEL 8",
-    "description": "RHEL 8 Java stack with OpenJDK 1.8 and Maven 3.5",
+    "description": "RHEL 8 Java stack with EAP 7.2, OpenJDK 11 and Maven 3.5",
     "scope": "general",
     "tags": [
+      "eap",
       "maven",
       "java"
     ],
@@ -21,6 +22,10 @@
       {
         "name": "Maven",
         "version": "3.5.0"
+      },
+      {
+        "name": "EAP",
+        "version": "7.2"
       }
     ],
     "workspaceConfig": {
@@ -39,6 +44,10 @@
                 "eap" : {
                   "port" : "8080",
                   "protocol" : "http"
+                },
+                "eap-debug": {
+                  "port": "8000",
+                  "protocol": "http"
                 }
               },
               "attributes" : {


### PR DESCRIPTION
add EAP to JDK 8 stack image (DO NOT MERGE until we have a working RHEL8-based EAP 7.2 JDK 8 stack (CRW-261)

Change-Id: I9b0ca02597550bdaa668c4bfa5d409c63c4a1ff2
Signed-off-by: nickboldt <nboldt@redhat.com>