### PR TITLE
Test E2E: Correct the 'userstory' tests to increase reliability

### DIFF
--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/ClangCppUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/ClangCppUserStoryTest.java
@@ -82,10 +82,10 @@ public class ClangCppUserStoryTest extends AbstractUserStoryTest {
     // check contents of autocomplete container
     editor.goToPosition(7, 44);
     editor.typeTextIntoEditor(Keys.ENTER.toString());
-    editor.typeTextIntoEditor("std::cou");
+    editor.typeTextIntoEditor("std::");
     editor.launchAutocompleteAndWaitContainer();
     editor.waitProposalIntoAutocompleteContainer("cout ostream");
-    editor.waitProposalIntoAutocompleteContainer("wcout wostream");
+    editor.waitProposalIntoAutocompleteContainer(" basic_ostream");
     editor.closeAutocomplete();
 
     editor.deleteCurrentLine();

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/SpringBootUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/SpringBootUserStoryTest.java
@@ -123,11 +123,14 @@ public class SpringBootUserStoryTest extends AbstractUserStoryTest {
   @Test(priority = 1)
   public void checkMainCodeAssistantFeatures() {
     seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
-    projectExplorer.quickExpandWithJavaScript();
+    projectExplorer.quickRevealToItemWithJavaScript(
+        PATH_TO_MAIN_PACKAGE + "/service/Greeting.java");
+    projectExplorer.quickRevealToItemWithJavaScript(
+        PATH_TO_MAIN_PACKAGE + "/service/GreetingEndpoint.java");
 
-    projectExplorer.openItemByPath(PATH_TO_MAIN_PACKAGE + "/service/GreetingEndpoint.java");
-    editor.waitActive();
     projectExplorer.openItemByPath(PATH_TO_MAIN_PACKAGE + "/service/Greeting.java");
+    editor.waitActive();
+    projectExplorer.openItemByPath(PATH_TO_MAIN_PACKAGE + "/service/GreetingEndpoint.java");
     editor.waitActive();
 
     checkGoToDeclarationFeature();
@@ -142,7 +145,7 @@ public class SpringBootUserStoryTest extends AbstractUserStoryTest {
   }
 
   private void checkGoToDeclarationFeature() {
-    editor.selectTabByName("GreetingEndpoint");
+    editor.waitTabVisibilityAndCheckFocus("GreetingEndpoint");
     editor.goToPosition(33, 24);
     editor.typeTextIntoEditor(F4.toString());
     editor.waitActiveTabFileName("Greeting");

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/ThorntailUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/ThorntailUserStoryTest.java
@@ -138,7 +138,7 @@ public class ThorntailUserStoryTest extends AbstractUserStoryTest {
     projectExplorer.quickRevealToItemWithJavaScript(pathToFile);
     projectExplorer.openItemByPath(pathToFile);
     editor.waitActive();
-    mavenPluginStatusBar.waitClosingInfoPanel();
+    mavenPluginStatusBar.waitClosingInfoPanel(400);
     editor.goToPosition(33, 87);
     editor.typeTextIntoEditor(ENTER.toString());
     editor.typeTextIntoEditor("n");

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/ThorntailUserStoryTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/userstory/ThorntailUserStoryTest.java
@@ -17,6 +17,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.eclipse.che.selenium.core.constant.TestBuildConstants.BUILD_SUCCESS;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.MULTIPLE;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
 import static org.openqa.selenium.Keys.ENTER;
 
@@ -138,7 +139,7 @@ public class ThorntailUserStoryTest extends AbstractUserStoryTest {
     projectExplorer.quickRevealToItemWithJavaScript(pathToFile);
     projectExplorer.openItemByPath(pathToFile);
     editor.waitActive();
-    mavenPluginStatusBar.waitClosingInfoPanel(400);
+    mavenPluginStatusBar.waitClosingInfoPanel(PREPARING_WS_TIMEOUT_SEC * 2);
     editor.goToPosition(33, 87);
     editor.typeTextIntoEditor(ENTER.toString());
     editor.typeTextIntoEditor("n");


### PR DESCRIPTION
* Change the expected proposal text of the autocomplete container in the _ClangCppUserStoryTest_
* Change the command to expand the project tree in the _SpringBootUserStoryTest_
* Change the wait timeout of closing maven plugin info panel in the _ThorntailUserStoryTest_ 