### PR TITLE
[Selenium] Select identity provider from providers list

### DIFF
--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/CodereadyOpenShiftLoginPage.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/CodereadyOpenShiftLoginPage.java
@@ -33,6 +33,7 @@ import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.pageobject.ocp.OpenShiftLoginPage;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
@@ -135,8 +136,15 @@ public class CodereadyOpenShiftLoginPage extends OpenShiftLoginPage {
   }
 
   public Boolean isIdentityProviderLinkVisible(String identityProviderName) {
-    return seleniumWebDriverHelper.isVisible(
-        By.xpath(format(IDENTITY_PROVIDER_LINK_XPATH, identityProviderName)));
+
+    try {
+      seleniumWebDriverHelper.waitVisibility(
+          By.xpath(format(IDENTITY_PROVIDER_LINK_XPATH, identityProviderName)), 2);
+    } catch (TimeoutException e) {
+      return false;
+    }
+
+    return true;
   }
 
   public void clickOnIdentityProviderLink(String identityProviderName) {

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/CodereadyOpenShiftLoginPage.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/CodereadyOpenShiftLoginPage.java
@@ -15,6 +15,7 @@ import static com.redhat.codeready.selenium.pageobject.CodereadyOpenShiftLoginPa
 import static com.redhat.codeready.selenium.pageobject.CodereadyOpenShiftLoginPage.Locators.CONFIRM_PASSWORD_INPUT_NAME;
 import static com.redhat.codeready.selenium.pageobject.CodereadyOpenShiftLoginPage.Locators.EMAIL_NAME;
 import static com.redhat.codeready.selenium.pageobject.CodereadyOpenShiftLoginPage.Locators.FIRST_NAME_NAME;
+import static com.redhat.codeready.selenium.pageobject.CodereadyOpenShiftLoginPage.Locators.IDENTITY_PROVIDER_LINK_XPATH;
 import static com.redhat.codeready.selenium.pageobject.CodereadyOpenShiftLoginPage.Locators.LAST_NAME_NAME;
 import static com.redhat.codeready.selenium.pageobject.CodereadyOpenShiftLoginPage.Locators.LOGIN_BUTTON_XPATH;
 import static com.redhat.codeready.selenium.pageobject.CodereadyOpenShiftLoginPage.Locators.LOGIN_TITLE_ID;
@@ -22,6 +23,7 @@ import static com.redhat.codeready.selenium.pageobject.CodereadyOpenShiftLoginPa
 import static com.redhat.codeready.selenium.pageobject.CodereadyOpenShiftLoginPage.Locators.REGISTER_LINK_XPATH;
 import static com.redhat.codeready.selenium.pageobject.CodereadyOpenShiftLoginPage.Locators.SUBMIT_BUTTON_XPATH;
 import static com.redhat.codeready.selenium.pageobject.CodereadyOpenShiftLoginPage.Locators.USERNAME_INPUT_NAME;
+import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 
@@ -30,6 +32,7 @@ import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.pageobject.ocp.OpenShiftLoginPage;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
@@ -50,6 +53,7 @@ public class CodereadyOpenShiftLoginPage extends OpenShiftLoginPage {
     String REGISTER_LINK_XPATH = "//a[text()='Register']";
     String SUBMIT_BUTTON_XPATH = "//input[@value='Submit']";
     String APPROVE_BUTTON_NAME = "approve";
+    String IDENTITY_PROVIDER_LINK_XPATH = "//a[@title='Log in with %s']";
   }
 
   @FindBy(name = FIRST_NAME_NAME)
@@ -128,5 +132,15 @@ public class CodereadyOpenShiftLoginPage extends OpenShiftLoginPage {
 
   public Boolean isApproveButtonVisible() {
     return seleniumWebDriverHelper.isVisible(approveButton);
+  }
+
+  public Boolean isIdentityProviderLinkVisible(String identityProviderName) {
+    return seleniumWebDriverHelper.isVisible(
+        By.xpath(format(IDENTITY_PROVIDER_LINK_XPATH, identityProviderName)));
+  }
+
+  public void clickOnIdentityProviderLink(String identityProviderName) {
+    seleniumWebDriverHelper.waitAndClick(
+        By.xpath(format(IDENTITY_PROVIDER_LINK_XPATH, identityProviderName)));
   }
 }

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/ocpoauth/LoginExistedUserWithOpenShiftOAuthTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/ocpoauth/LoginExistedUserWithOpenShiftOAuthTest.java
@@ -86,6 +86,9 @@ public class LoginExistedUserWithOpenShiftOAuthTest {
     seleniumWebDriver.navigate().to(testDashboardUrlProvider.get());
 
     cheLoginPage.loginWithOpenShiftOAuth();
+    if (codereadyOpenShiftLoginPage.isIdentityProviderLinkVisible("htpasswd_provider")) {
+      codereadyOpenShiftLoginPage.clickOnIdentityProviderLink("htpasswd_provider");
+    }
     codereadyOpenShiftLoginPage.login(openShiftUsername, openShiftPassword);
 
     // authorize ocp-client to access OpenShift account

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/ocpoauth/LoginExistedUserWithOpenShiftOAuthTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/ocpoauth/LoginExistedUserWithOpenShiftOAuthTest.java
@@ -14,6 +14,7 @@ package com.redhat.codeready.selenium.ocpoauth;
 import static com.redhat.codeready.selenium.pageobject.dashboard.CodereadyNewWorkspace.CodereadyStacks.JAVA_DEFAULT;
 import static java.lang.String.format;
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertEquals;
 
 import com.google.common.collect.ImmutableList;
@@ -35,6 +36,7 @@ import org.eclipse.che.selenium.pageobject.ocp.AuthorizeOpenShiftAccessPage;
 import org.eclipse.che.selenium.pageobject.ocp.OpenShiftProjectCatalogPage;
 import org.eclipse.che.selenium.pageobject.site.CheLoginPage;
 import org.eclipse.che.selenium.pageobject.site.FirstBrokerProfilePage;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -43,10 +45,11 @@ public class LoginExistedUserWithOpenShiftOAuthTest {
 
   private static final String WORKSPACE_NAME = generate("workspace", 4);
   private static final String PROJECT = "kitchensink-example";
-  public static final String LOGIN_TO_CHE_WITH_OPENSHIFT_OAUTH_MESSAGE_TEMPLATE =
+  private static final String LOGIN_TO_CHE_WITH_OPENSHIFT_OAUTH_MESSAGE_TEMPLATE =
       "Authenticate as %s to link your account with openshift-v3";
-  public static final String USER_ALREADY_EXISTS_ERROR_MESSAGE_TEMPLATE =
+  private static final String USER_ALREADY_EXISTS_ERROR_MESSAGE_TEMPLATE =
       "User with username %s already exists. How do you want to continue?";
+  private static final String IDENTITY_PROVIDER_NAME = "htpasswd_provider";
 
   private TestWorkspace testWorkspace;
   private static final TestUser testUser = getTestUser();
@@ -86,8 +89,8 @@ public class LoginExistedUserWithOpenShiftOAuthTest {
     seleniumWebDriver.navigate().to(testDashboardUrlProvider.get());
 
     cheLoginPage.loginWithOpenShiftOAuth();
-    if (codereadyOpenShiftLoginPage.isIdentityProviderLinkVisible("htpasswd_provider")) {
-      codereadyOpenShiftLoginPage.clickOnIdentityProviderLink("htpasswd_provider");
+    if (codereadyOpenShiftLoginPage.isIdentityProviderLinkVisible(IDENTITY_PROVIDER_NAME)) {
+      codereadyOpenShiftLoginPage.clickOnIdentityProviderLink(IDENTITY_PROVIDER_NAME);
     }
     codereadyOpenShiftLoginPage.login(openShiftUsername, openShiftPassword);
 
@@ -98,7 +101,12 @@ public class LoginExistedUserWithOpenShiftOAuthTest {
     }
 
     // fill profile page
-    firstBrokerProfilePage.submit(testUser);
+    try {
+      firstBrokerProfilePage.submit(testUser);
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known permanent OCP4.x failure https://issues.jboss.org/browse/CRW-202");
+    }
 
     // apply OCP user information to Codeready user account
     assertEquals(firstBrokerProfilePage.getErrorAlert(), expectedError);

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/ocpoauth/LoginNewUserWithOpenShiftOAuthTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/ocpoauth/LoginNewUserWithOpenShiftOAuthTest.java
@@ -82,6 +82,9 @@ public class LoginNewUserWithOpenShiftOAuthTest {
     seleniumWebDriver.navigate().to(testDashboardUrlProvider.get());
 
     cheLoginPage.loginWithOpenShiftOAuth();
+    if (codereadyOpenShiftLoginPage.isIdentityProviderLinkVisible("htpasswd_provider")) {
+      codereadyOpenShiftLoginPage.clickOnIdentityProviderLink("htpasswd_provider");
+    }
     codereadyOpenShiftLoginPage.login(openShiftUsername, openShiftPassword);
 
     // authorize ocp-client to access OpenShift account


### PR DESCRIPTION
This PR adds methods to ```CodereadyOpenShiftLoginPage``` pageobject for selection identity provider from providers list on ```Log in with...``` page and add info about known https://issues.jboss.org/browse/CRW-202 issue to selenium tests from ```ocpoauth``` package.

![com redhat codeready selenium ocpoauth LoginExistedUserWithOpenShiftOAuthTest checkWorkspaceOSProjectCreationAndRemoval_time-1562273249081-millis](https://user-images.githubusercontent.com/7760565/60972246-8d8a8780-a32e-11e9-97af-76e57e745bb1.png)
