### PR TITLE
Fix locator of OpenShift OAuth link button in e2e tests

### DIFF
--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/core/CodereadySeleniumSuiteModule.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/core/CodereadySeleniumSuiteModule.java
@@ -15,12 +15,10 @@ import com.google.inject.AbstractModule;
 import com.redhat.codeready.selenium.core.client.keycloak.cli.CodeReadyOpenShiftKeycloakCliCommandExecutor;
 import com.redhat.codeready.selenium.core.executor.hotupdate.CodeReadyHotUpdateUtil;
 import com.redhat.codeready.selenium.core.utils.CodeReadyWorkspaceDtoDeserializer;
-import com.redhat.codeready.selenium.pageobject.site.CodereadyLoginPage;
 import org.eclipse.che.selenium.core.CheSeleniumSuiteModule;
 import org.eclipse.che.selenium.core.client.keycloak.cli.OpenShiftKeycloakCliCommandExecutor;
 import org.eclipse.che.selenium.core.executor.hotupdate.HotUpdateUtil;
 import org.eclipse.che.selenium.core.utils.WorkspaceDtoDeserializer;
-import org.eclipse.che.selenium.pageobject.site.CheLoginPage;
 
 /**
  * Guice module per suite.
@@ -38,6 +36,5 @@ public class CodereadySeleniumSuiteModule extends AbstractModule {
 
     bind(HotUpdateUtil.class).to(CodeReadyHotUpdateUtil.class);
     bind(WorkspaceDtoDeserializer.class).to(CodeReadyWorkspaceDtoDeserializer.class);
-    bind(CheLoginPage.class).to(CodereadyLoginPage.class);
   }
 }

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/core/CodereadySeleniumSuiteModule.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/core/CodereadySeleniumSuiteModule.java
@@ -15,10 +15,12 @@ import com.google.inject.AbstractModule;
 import com.redhat.codeready.selenium.core.client.keycloak.cli.CodeReadyOpenShiftKeycloakCliCommandExecutor;
 import com.redhat.codeready.selenium.core.executor.hotupdate.CodeReadyHotUpdateUtil;
 import com.redhat.codeready.selenium.core.utils.CodeReadyWorkspaceDtoDeserializer;
+import com.redhat.codeready.selenium.pageobject.site.CodereadyLoginPage;
 import org.eclipse.che.selenium.core.CheSeleniumSuiteModule;
 import org.eclipse.che.selenium.core.client.keycloak.cli.OpenShiftKeycloakCliCommandExecutor;
 import org.eclipse.che.selenium.core.executor.hotupdate.HotUpdateUtil;
 import org.eclipse.che.selenium.core.utils.WorkspaceDtoDeserializer;
+import org.eclipse.che.selenium.pageobject.site.CheLoginPage;
 
 /**
  * Guice module per suite.
@@ -36,5 +38,6 @@ public class CodereadySeleniumSuiteModule extends AbstractModule {
 
     bind(HotUpdateUtil.class).to(CodeReadyHotUpdateUtil.class);
     bind(WorkspaceDtoDeserializer.class).to(CodeReadyWorkspaceDtoDeserializer.class);
+    bind(CheLoginPage.class).to(CodereadyLoginPage.class);
   }
 }

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/site/CodereadyLoginPage.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/site/CodereadyLoginPage.java
@@ -1,0 +1,48 @@
+/*
+* Copyright (c) 2019 Red Hat, Inc.
+
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-2.0
+*
+* Contributors:
+*   Red Hat, Inc. - initial API and implementation
+*/
+package com.redhat.codeready.selenium.pageobject.site;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
+import org.eclipse.che.selenium.pageobject.site.CheLoginPage;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/** @author Dmytro Nochevnov
+ * TODO implement it in upstream Che 7 and remove in CRW 2.0
+ * */
+@Singleton
+public class CodereadyLoginPage extends CheLoginPage {
+
+  protected interface Locators {
+    String OPEN_SHIFT_OAUTH_LINK_XPATH = "//a[@id[contains(.,'zocial-openshift-v')]]";
+  }
+
+  @FindBy(xpath = Locators.OPEN_SHIFT_OAUTH_LINK_XPATH)
+  private WebElement openShiftOAuthLink;
+
+  private final SeleniumWebDriverHelper seleniumWebDriverHelper;
+
+  @Inject
+  public CodereadyLoginPage(
+      SeleniumWebDriver seleniumWebDriver, SeleniumWebDriverHelper seleniumWebDriverHelper) {
+    super(seleniumWebDriver, seleniumWebDriverHelper);
+
+    this.seleniumWebDriverHelper = seleniumWebDriverHelper;
+  }
+
+  public void loginWithOpenShiftOAuth() {
+    seleniumWebDriverHelper.waitAndClick(openShiftOAuthLink);
+  }
+}

--- a/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/site/CodereadyLoginPage.java
+++ b/test/codeready-test-e2e/src/main/java/com/redhat/codeready/selenium/pageobject/site/CodereadyLoginPage.java
@@ -19,9 +19,7 @@ import org.eclipse.che.selenium.pageobject.site.CheLoginPage;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
-/** @author Dmytro Nochevnov
- * TODO implement it in upstream Che 7 and remove in CRW 2.0
- * */
+/** @author Dmytro Nochevnov TODO implement it in upstream Che 7 and remove in CRW 2.0 */
 @Singleton
 public class CodereadyLoginPage extends CheLoginPage {
 

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/ocpoauth/LoginExistedUserWithOpenShiftOAuthTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/ocpoauth/LoginExistedUserWithOpenShiftOAuthTest.java
@@ -22,6 +22,7 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.redhat.codeready.selenium.pageobject.CodereadyOpenShiftLoginPage;
 import com.redhat.codeready.selenium.pageobject.dashboard.CodeReadyCreateWorkspaceHelper;
+import com.redhat.codeready.selenium.pageobject.site.CodereadyLoginPage;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.provider.TestDashboardUrlProvider;
@@ -34,7 +35,6 @@ import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
 import org.eclipse.che.selenium.pageobject.ocp.AuthorizeOpenShiftAccessPage;
 import org.eclipse.che.selenium.pageobject.ocp.OpenShiftProjectCatalogPage;
-import org.eclipse.che.selenium.pageobject.site.CheLoginPage;
 import org.eclipse.che.selenium.pageobject.site.FirstBrokerProfilePage;
 import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.AfterClass;
@@ -62,7 +62,7 @@ public class LoginExistedUserWithOpenShiftOAuthTest {
   @Named("env.openshift.password")
   private String openShiftPassword;
 
-  @Inject private CheLoginPage cheLoginPage;
+  @Inject private CodereadyLoginPage codereadyLoginPage;
   @Inject private CodereadyOpenShiftLoginPage codereadyOpenShiftLoginPage;
   @Inject private FirstBrokerProfilePage firstBrokerProfilePage;
   @Inject private AuthorizeOpenShiftAccessPage authorizeOpenShiftAccessPage;
@@ -88,7 +88,7 @@ public class LoginExistedUserWithOpenShiftOAuthTest {
     // go to login page of Codeready
     seleniumWebDriver.navigate().to(testDashboardUrlProvider.get());
 
-    cheLoginPage.loginWithOpenShiftOAuth();
+    codereadyLoginPage.loginWithOpenShiftOAuth();
     if (codereadyOpenShiftLoginPage.isIdentityProviderLinkVisible(IDENTITY_PROVIDER_NAME)) {
       codereadyOpenShiftLoginPage.clickOnIdentityProviderLink(IDENTITY_PROVIDER_NAME);
     }
@@ -115,8 +115,8 @@ public class LoginExistedUserWithOpenShiftOAuthTest {
     // login into Codeready again
     String expectedInfo =
         format(LOGIN_TO_CHE_WITH_OPENSHIFT_OAUTH_MESSAGE_TEMPLATE, testUser.getName());
-    assertEquals(cheLoginPage.getInfoAlert(), expectedInfo);
-    cheLoginPage.loginWithPredefinedUsername(testUser.getPassword());
+    assertEquals(codereadyLoginPage.getInfoAlert(), expectedInfo);
+    codereadyLoginPage.loginWithPredefinedUsername(testUser.getPassword());
 
     // create and open workspace
     testWorkspace =

--- a/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/ocpoauth/LoginNewUserWithOpenShiftOAuthTest.java
+++ b/test/codeready-test-e2e/src/test/java/com/redhat/codeready/selenium/ocpoauth/LoginNewUserWithOpenShiftOAuthTest.java
@@ -20,6 +20,7 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.redhat.codeready.selenium.pageobject.CodereadyOpenShiftLoginPage;
 import com.redhat.codeready.selenium.pageobject.dashboard.CodeReadyCreateWorkspaceHelper;
+import com.redhat.codeready.selenium.pageobject.site.CodereadyLoginPage;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.provider.TestDashboardUrlProvider;
@@ -31,7 +32,6 @@ import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
 import org.eclipse.che.selenium.pageobject.ocp.AuthorizeOpenShiftAccessPage;
 import org.eclipse.che.selenium.pageobject.ocp.OpenShiftProjectCatalogPage;
-import org.eclipse.che.selenium.pageobject.site.CheLoginPage;
 import org.eclipse.che.selenium.pageobject.site.FirstBrokerProfilePage;
 import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.AfterClass;
@@ -58,7 +58,7 @@ public class LoginNewUserWithOpenShiftOAuthTest {
   @Named("env.openshift.regular.email")
   private String openShiftEmail;
 
-  @Inject private CheLoginPage cheLoginPage;
+  @Inject private CodereadyLoginPage codereadyLoginPage;
   @Inject private CodereadyOpenShiftLoginPage codereadyOpenShiftLoginPage;
   @Inject private FirstBrokerProfilePage firstBrokerProfilePage;
   @Inject private AuthorizeOpenShiftAccessPage authorizeOpenShiftAccessPage;
@@ -82,7 +82,7 @@ public class LoginNewUserWithOpenShiftOAuthTest {
     // go to login page of Codeready
     seleniumWebDriver.navigate().to(testDashboardUrlProvider.get());
 
-    cheLoginPage.loginWithOpenShiftOAuth();
+    codereadyLoginPage.loginWithOpenShiftOAuth();
     if (codereadyOpenShiftLoginPage.isIdentityProviderLinkVisible(IDENTITY_PROVIDER_NAME)) {
       codereadyOpenShiftLoginPage.clickOnIdentityProviderLink(IDENTITY_PROVIDER_NAME);
     }


### PR DESCRIPTION
This PR fixes locator of *Openshift v4* button on login page in E2E java selenium tests:

![Screenshot from 2019-07-15 14-56-12](https://user-images.githubusercontent.com/1197777/61224337-1470a300-a727-11e9-867b-bcde28072377.png)

It is related to https://issues.jboss.org/browse/CRW-327 and is required for https://issues.jboss.org/browse/CRW-202.

Signed-off-by: Dmytro Nochevnov <dnochevn@redhat.com>