### PR TITLE
Update metadata to .NET 2.1 to reflect version used

### DIFF
--- a/ide/codeready-ide-samples/src/main/resources/samples.json
+++ b/ide/codeready-ide-samples/src/main/resources/samples.json
@@ -325,7 +325,7 @@
     "name": "dotnet-web-simple",
     "displayName": "dotnet-web-simple",
     "path": "/dotnet-web-simple",
-    "description": "A simple .NET 2.0 web sample.",
+    "description": "A simple .NET 2.1 web sample.",
     "projectType": "csharp",
     "mixins": [],
     "attributes": {

--- a/ide/codeready-ide-stacks/src/main/resources/stacks.json
+++ b/ide/codeready-ide-stacks/src/main/resources/stacks.json
@@ -758,7 +758,7 @@
     "id": "dotnet-default",
     "creator": "ide",
     "name": ".NET",
-    "description": ".NET 2.0 stack with .NET Core SDK and Runtime",
+    "description": ".NET 2.1 stack with .NET Core SDK and Runtime",
     "scope": "general",
     "tags": [
       "dotnet"


### PR DESCRIPTION
Renaming stack to .NET Core 2.1 for consistency with the actual version of the `registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8` image used.  See supporting documentation, attribute `DOTNET_CORE_VERSION=2.1` [1].  As an aside, version 2.0 was deprecated in October 2018 [2].


[1]
https://access.redhat.com/containers/?tab=tech-details#/registry.access.redhat.com/codeready-workspaces/stacks-dotnet-rhel8

[2]
https://dotnet.microsoft.com/platform/support/policy/dotnet-core
