### PR TITLE
Add `npm install` into `web-nodejs-simple` sample run command.

### DIFF
--- a/ide/codeready-ide-samples/src/main/resources/samples.json
+++ b/ide/codeready-ide-samples/src/main/resources/samples.json
@@ -555,7 +555,7 @@
       {
         "name": "run",
         "type": "custom",
-        "commandLine": "cd ${current.project.path} \nnode app/app.js",
+        "commandLine": "cd ${current.project.path} \nnpm i \nnode app/app.js",
         "attributes": {
           "previewUrl": "${server.3000/tcp}",
           "goal": "Run"


### PR DESCRIPTION
Should fix https://issues.jboss.org/browse/CRW-368

Signed-off-by: Radim Hopp <rhopp@redhat.com>