### PR TITLE
Don't change npm config twice

### DIFF
--- a/theia/Jenkinsfile
+++ b/theia/Jenkinsfile
@@ -42,16 +42,7 @@ timeout(120) {
 
 		// TODO replace Alpine with UBI
 		// sh "cp crw/dockerfiles/che-theia/Dockerfile che-theia/dockerfiles/theia/Dockefile"
-
-		// CRW-360 use RH NPM mirror
-		sh "sed -i 's|https://registry.yarnpkg.com/|https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/|g' che-theia/yarn.lock"
-		sh "npm config set registry https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/; npm config get registry"
-		sh "npm config set strict-ssl false"
-		sh "npm config ls -l"
-		sh "cd che-theia && npm install yarn"
-		sh "yarn config set registry https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/; yarn config get registry"
-		sh "yarn --version"
-
+		
 		// TODO make this a for loop or split into stages
 		sh "cd che-theia; ./build.sh"
 		// sh "cd che-theia/dockerfiles/theia-dev && ./build.sh --no-tests --build-args:GITHUB_TOKEN=${GITHUB_TOKEN},THEIA_VERSION=${che_theia_version} --tag:${che_theia_tag} --branch:${che_theia_branch} --git-ref:${che_theia_gitref}"

--- a/theia/Jenkinsfile
+++ b/theia/Jenkinsfile
@@ -20,20 +20,20 @@ timeout(120) {
 	node("${node}"){ stage "Build Theia"
 		cleanWs()
 		// for private repo, use checkout(credentialsId: 'devstudio-release')
-		checkout([$class: 'GitSCM', 
-			branches: [[name: "${branchToBuildCRW}"]], 
-			doGenerateSubmoduleConfigurations: false, 
-			poll: true,
-			extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: "crw"]], 
-			submoduleCfg: [], 
-			userRemoteConfigs: [[url: "https://github.com/redhat-developer/codeready-workspaces.git"]]])
-		checkout([$class: 'GitSCM', 
-			branches: [[name: "${branchToBuildCheTheia}"]], 
-			doGenerateSubmoduleConfigurations: false, 
-			poll: true,
-			extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: "che-theia"]], 
-			submoduleCfg: [], 
-			userRemoteConfigs: [[url: "https://github.com/eclipse/che-theia.git"]]])
+		checkout([$class: 'GitSCM',
+				  branches: [[name: "${branchToBuildCRW}"]],
+				  doGenerateSubmoduleConfigurations: false,
+				  poll: true,
+				  extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: "crw"]],
+				  submoduleCfg: [],
+				  userRemoteConfigs: [[url: "https://github.com/redhat-developer/codeready-workspaces.git"]]])
+		checkout([$class: 'GitSCM',
+				  branches: [[name: "${branchToBuildCheTheia}"]],
+				  doGenerateSubmoduleConfigurations: false,
+				  poll: true,
+				  extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: "che-theia"]],
+				  submoduleCfg: [],
+				  userRemoteConfigs: [[url: "https://github.com/eclipse/che-theia.git"]]])
 		installNPM()
 		//sh '''#!/bin/bash -xe
 		//'''
@@ -42,7 +42,17 @@ timeout(120) {
 
 		// TODO replace Alpine with UBI
 		// sh "cp crw/dockerfiles/che-theia/Dockerfile che-theia/dockerfiles/theia/Dockefile"
-		
+
+		// CRW-360 use RH NPM mirror
+		sh "sed -i 's|https://registry.yarnpkg.com/|https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/|g' che-theia/yarn.lock"
+		sh "sed -i 's/yarn install/yarn install --verbose/' che-theia/dockerfiles/theia-endpoint-runtime/Dockerfile"
+//		sh "npm config set registry https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/; npm config get registry"
+//		sh "npm config set strict-ssl false"
+//		sh "npm config ls -l"
+//		sh "cd che-theia && npm install yarn"
+//		sh "yarn config set registry https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/; yarn config get registry"
+//		sh "yarn --version"
+
 		// TODO make this a for loop or split into stages
 		sh "cd che-theia; ./build.sh"
 		// sh "cd che-theia/dockerfiles/theia-dev && ./build.sh --no-tests --build-args:GITHUB_TOKEN=${GITHUB_TOKEN},THEIA_VERSION=${che_theia_version} --tag:${che_theia_tag} --branch:${che_theia_branch} --git-ref:${che_theia_gitref}"

--- a/theia/Jenkinsfile
+++ b/theia/Jenkinsfile
@@ -45,13 +45,7 @@ timeout(120) {
 
 		// CRW-360 use RH NPM mirror
 		sh "sed -i 's|https://registry.yarnpkg.com/|https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/|g' che-theia/yarn.lock"
-		sh "sed -i 's/yarn install/yarn install --verbose/' che-theia/dockerfiles/theia-endpoint-runtime/Dockerfile"
-//		sh "npm config set registry https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/; npm config get registry"
-//		sh "npm config set strict-ssl false"
-//		sh "npm config ls -l"
-//		sh "cd che-theia && npm install yarn"
-//		sh "yarn config set registry https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/; yarn config get registry"
-//		sh "yarn --version"
+		sh "sed -i 's|https://registry.yarnpkg.com/|https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/|g' che-theia/generator/tests/production/assembly/yarn.lock"
 
 		// TODO make this a for loop or split into stages
 		sh "cd che-theia; ./build.sh"


### PR DESCRIPTION
This is clean up of previous changes to use RH NPM mirror, which look unnecessary after commit https://github.com/redhat-developer/codeready-workspaces/commit/5f9d415baacbea300e1b8378d585d7cc0aa2d124 and [fixed CI slaves images](https://gitlab.cee.redhat.com/codeready-workspaces/cloud-slaves/commit/09bea382363e35bfea0439e947d6db998dcee947).

Build result could be found [here](https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/crw-theia_master/68/).

Signed-off-by: Dmytro Nochevnov <dnochevn@redhat.com>