### PR TITLE
 web-nodejs-simple devfile

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/web-nodejs-simple/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/web-nodejs-simple/devfile.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: 1.0.0
+metadata:
+  generateName: nodejs-
+projects:
+  - name: nodejs-web-app
+    source:
+      type: git
+      location: "https://github.com/che-samples/web-nodejs-sample.git"
+components:
+  - type: chePlugin
+    id: che-incubator/typescript/latest
+    memoryLimit: 512Mi
+  - type: dockerimage
+    alias: nodejs
+    image: quay.io/crw/stacks-node-rhel8:2.0-3
+    memoryLimit: 512Mi
+    endpoints:
+      - name: "nodejs"
+        port: 3000
+    mountSources: true
+commands:
+  - name: download dependencies
+    actions:
+      - type: exec
+        component: nodejs
+        command: npm install
+        workdir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app
+  - name: run the web app
+    actions:
+      - type: exec
+        component: nodejs
+        command: nodemon app.js
+        workdir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app
+  - name: run the web app (debugging enabled)
+    actions:
+      - type: exec
+        component: nodejs
+        command: nodemon --inspect app.js
+        workdir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app
+  - name: stop the web app
+    actions:
+      - type: exec
+        component: nodejs
+        command: >-
+          node_server_pids=$(pgrep -fx '.*nodemon (--inspect )?app.js' | tr "\\n" " ") &&
+          echo "Stopping node server with PIDs: ${node_server_pids}" && 
+          kill -15 ${node_server_pids} &>/dev/null && echo 'Done.'
+  - name: Attach remote debugger
+    actions:
+      - type: vscode-launch
+        referenceContent: |
+          {
+            "version": "0.2.0",
+            "configurations": [
+              {
+                "type": "node",
+                "request": "attach",
+                "name": "Attach to Remote",
+                "address": "localhost",
+                "port": 9229,
+                "localRoot": "${workspaceFolder}",
+                "remoteRoot": "${workspaceFolder}"
+              }
+            ]
+          }

--- a/dependencies/che-devfile-registry/devfiles/web-nodejs-simple/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/web-nodejs-simple/meta.yaml
@@ -1,0 +1,6 @@
+---
+displayName: NodeJS Express Web Application
+description: Stack with NodeJS 10
+tags: ["NodeJS", "Express", "ubi8"]
+icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-node.svg
+globalMemoryLimit: 1686Mi


### PR DESCRIPTION
This PR brings in the web-nodejs-simple devfile.

This devfile differs from the devfile in the che-devfile-registry in 2 ways:
- Uses registry.redhat.io/codeready-workspaces/stacks-node-rhel8 which includes node 10
- nodemon isn't available in the current version of the image so it has replaced all references of nodemon with node (though I believe @nickboldt is working on this so that this image has nodemon)

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>