### PR TITLE
WIP - Added nodejs mongo devfile

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/nodejs-mongo/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/nodejs-mongo/devfile.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: 1.0.0
+metadata:
+  generateName: nodejs-mongo-
+projects:
+  - name: nodejs-mongodb-sample
+    source:
+      type: git
+      location: "https://github.com/jpinkney/nodejs-mongodb-sample"
+components:
+  - type: chePlugin
+    id: che-incubator/typescript/latest
+    memoryLimit: 512Mi
+  - type: dockerimage
+    alias: nodejs
+    image: registry.redhat.io/codeready-workspaces/stacks-node-rhel8
+    env:
+      # The values below are used to set up the environment for running the application
+      - name: SECRET
+        value: 220fd770-c028-480d-8f95-f84353c7d55a
+      - name: NODE_ENV
+        value: production
+    memoryLimit: 512Mi
+    endpoints:
+      - name: "nodejs"
+        port: 8080
+    mountSources: true
+  - type: dockerimage
+    alias: mongo
+    image: registry.redhat.io/rhscl/mongodb-34-rhel7
+    memoryLimit: 512Mi
+    env:
+      - name: MONGODB_USER
+        value: user
+      - name: MONGODB_PASSWORD
+        value: password
+      - name: MONGODB_DATABASE
+        value: guestbook
+      - name: MONGODB_ADMIN_PASSWORD
+        value: password
+    volumes:
+      - name: mongo-storage
+        containerPath: /var/lib/mongodb/data
+    endpoints:
+      - name: mongodb-34-rhel7
+        port: 27017
+        attributes:
+          discoverable: "true"
+          public: "false"
+commands:
+  - name: run the application
+    actions:
+      - type: exec
+        component: nodejs
+        command: npm install && node --inspect=9229 app.js
+        workdir: ${CHE_PROJECTS_ROOT}/nodejs-mongodb-sample
+  - name: Debug remote node application
+    actions:
+      - type: vscode-launch
+        referenceContent: |
+          {
+          "version": "0.2.0",
+          "configurations": [
+            {
+              "type": "node",
+              "name": "Debug (Attach) - Remote",
+              "request": "attach",
+              "port": 9229
+            }]
+          }

--- a/dependencies/che-devfile-registry/devfiles/nodejs-mongo/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/nodejs-mongo/meta.yaml
@@ -1,0 +1,6 @@
+---
+displayName: NodeJS MongoDB Web Application
+description: Stack with NodeJS 10 and MongoDB 3.4
+tags: ["NodeJS", "Express", "MongoDB", "RealWorld", "ubi8", "Centos"]
+icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-node.svg
+globalMemoryLimit: 1686Mi


### PR DESCRIPTION
This PR adds the nodejs mongo devfile.

All images have been replaced from upstream to use ones from registry.redhat.io.

Currently, the sample this devfile uses lives in a fork of the upstream sample. This fork is needed because the sample includes kubernetes yaml files needed for deploying the application that hardcodes image names. The fork changes the images to be images from the red hat registry.

 In order for this devfile to be merged (and WIP removed) we need to have this modified sample be in a better location.

Tested on che.openshift.io.

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>