### PR TITLE
Add dotnet, java maven and jboss devfiles

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/dotnet/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/dotnet/devfile.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: 1.0.0
+metadata:
+  generateName: dotnet-
+projects:
+  -
+    name: dotnet-web-simple
+    source:
+      type: git
+      location: "https://github.com/che-samples/dotnet-web-simple"
+components:
+  -
+    type: chePlugin
+    alias: omnisharp
+    id: redhat-developer/che-omnisharp-plugin/latest
+    memoryLimit: 1024Mi
+  -
+    type: dockerimage
+    alias: dotnet
+    image: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8
+    memoryLimit: 512Mi
+    endpoints:
+      - name: '5000/tcp'
+        port: 5000
+    mountSources: true
+    volumes:
+      - name: dotnet
+        containerPath: "/home/user"
+commands:
+  -
+    name: update dependencies
+    actions:
+      - type: exec
+        component: dotnet
+        command: "dotnet restore"
+        workdir: ${CHE_PROJECTS_ROOT}/dotnet-web-simple
+  -
+    name: run
+    actions:
+      - type: exec
+        component: dotnet
+        command: "dotnet run"
+        workdir: ${CHE_PROJECTS_ROOT}/dotnet-web-simple

--- a/dependencies/che-devfile-registry/devfiles/dotnet/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/dotnet/meta.yaml
@@ -1,0 +1,6 @@
+---
+displayName: ".NET"
+description: .NET 2.1 stack with .NET Core SDK and Runtime
+tags: [".NET", "C#"]
+icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-dotnet.svg
+globalMemoryLimit: 2198Mi

--- a/dependencies/che-devfile-registry/devfiles/java-eap-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/java-eap-maven/devfile.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: 1.0.0
+metadata:
+  generateName: java-eap-maven-
+projects:
+  -
+    name: kitchensink-example
+    source:
+      type: git
+      location: "https://github.com/che-samples/kitchensink-example"
+components:
+  -
+    type: chePlugin
+    id: redhat/java8/latest
+  -
+    type: dockerimage
+    alias: maven
+    image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8
+    env:
+      - name: MAVEN_CONFIG
+        value: /home/jboss/.m2
+      - name: MAVEN_OPTS
+        value: "-Xmx200m -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"
+    memoryLimit: 512Mi
+    endpoints:
+      - name: 'eap'
+        port: 8080
+    mountSources: true
+    volumes:
+      - name: m2
+        containerPath: /home/jboss/.m2
+commands:
+  -
+    name: build
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "mvn clean install"
+        workdir: ${CHE_PROJECTS_ROOT}/kitchensink-example
+  -
+    name: build and run in debug
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "mvn clean install && cp target/*.war /opt/eap/standalone/deployments/ROOT.war && export JAVA_OPTS_APPEND=-Dsun.util.logging.disableCallerCheck=true && /opt/eap/bin/standalone.sh -b 0.0.0.0 --debug 8000"
+        workdir: ${CHE_PROJECTS_ROOT}/kitchensink-example
+  -
+    name: copy war
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "cp target/*.war /opt/eap/standalone/deployments/ROOT.war"
+        workdir: ${CHE_PROJECTS_ROOT}/kitchensink-example
+  -
+    name: hot update
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "mvn clean install && cp target/*.war /opt/eap/standalone/deployments/ROOT.war"
+        workdir: ${CHE_PROJECTS_ROOT}/kitchensink-example
+  -
+    name: dependency analysis
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "${HOME}/stack-analysis.sh -f ${CHE_PROJECTS_ROOT}/kitchensink-example/pom.xml -p ${CHE_PROJECTS_ROOT}/kitchensink-example"
+  -
+    name: Debug (Attach)
+    actions:
+    - type: vscode-launch
+      referenceContent: |
+        {
+        "version": "0.2.0",
+        "configurations": [
+        {
+            "type": "java",
+            "request": "attach",
+            "name": "Debug (Attach)",
+            "hostName": "localhost",
+            "port": 8000
+        }
+        ]
+        }

--- a/dependencies/che-devfile-registry/devfiles/java-eap-maven/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/java-eap-maven/meta.yaml
@@ -1,0 +1,6 @@
+---
+displayName: Java EAP Maven
+description: RHEL 8 Java stack with EAP 7.2, OpenJDK 1.8 and Maven 3.5
+tags: ["Java", "OpenJDK", "Maven", "EAP"]
+icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-jboss.svg
+globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/java-eap-thorntail/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/java-eap-thorntail/devfile.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: 1.0.0
+metadata:
+  generateName: java-eap-thorntail-
+projects:
+  -
+    name: rest-http-redhat
+    source:
+      type: git
+      location: "https://github.com/thorntail-examples/rest-http-redhat"
+components:
+  -
+    type: chePlugin
+    id: redhat/java8/latest
+  -
+    type: dockerimage
+    alias: maven
+    image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8
+    env:
+      - name: MAVEN_CONFIG
+        value: /home/jboss/.m2
+      - name: JAVA_OPTS
+        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"
+      - name: MAVEN_OPTS
+        value: $(JAVA_OPTS)
+    memoryLimit: 768Mi
+    endpoints:
+      - name: 'eap'
+        port: 8080
+    mountSources: true
+    volumes:
+      - name: m2
+        containerPath: /home/jboss/.m2
+commands:
+  -
+    name: build
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "MAVEN_OPTS='-Xmx200m' && mvn clean install -DskipTests"
+        workdir: ${CHE_PROJECTS_ROOT}/rest-http-redhat
+  -
+    name: run
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "MAVEN_OPTS='-Xmx200m' && mvn clean install -DskipTests && java -jar target/*.jar -Djava.net.preferIPv4Stack=true"
+        workdir: ${CHE_PROJECTS_ROOT}/rest-http-redhat
+  -
+    name: debug
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "MAVEN_OPTS='-Xmx200m' && mvn clean install -DskipTests && java -agentlib:jdwp=transport=dt_socket,address=5005,server=y,suspend=n -jar target/*.jar -Djava.net.preferIPv4Stack=true"
+        workdir: ${CHE_PROJECTS_ROOT}/rest-http-redhat
+  -
+    name: deploy to OpenShift
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "mvn fabric8:deploy -Popenshift -DskipTests"
+        workdir: ${CHE_PROJECTS_ROOT}/rest-http-redhat
+  -        
+    name: dependency analysis
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "${HOME}/stack-analysis.sh -f ${CHE_PROJECTS_ROOT}/rest-http-redhat/pom.xml -p ${CHE_PROJECTS_ROOT}/rest-http-redhat"
+  -
+    name: Debug (Attach)
+    actions:
+    - type: vscode-launch
+      referenceContent: |
+        {
+        "version": "0.2.0",
+        "configurations": [
+        {
+            "type": "java",
+            "request": "attach",
+            "name": "Debug (Attach)",
+            "hostName": "localhost",
+            "port": 5005
+        }
+        ]
+        }

--- a/dependencies/che-devfile-registry/devfiles/java-eap-thorntail/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/java-eap-thorntail/meta.yaml
@@ -1,0 +1,6 @@
+---
+displayName: Thorntail REST HTTP
+description: Quickstart to expose a REST Greeting endpoint using Thorntail
+tags: ["Java", "OpenJDK", "Maven", "EAP"]
+icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-jboss.svg
+globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/java-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/java-maven/devfile.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: 1.0.0
+metadata:
+  generateName: java-maven-
+projects:
+  -
+    name: console-java-simple
+    source:
+      type: git
+      location: "https://github.com/che-samples/console-java-simple"
+components:
+  -
+    type: chePlugin
+    id: redhat/java8/latest
+  -
+    type: dockerimage
+    alias: maven
+    image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8
+    env:
+      - name: MAVEN_CONFIG
+        value: /home/jboss/.m2
+      - name: JAVA_OPTS
+        value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"
+      - name: MAVEN_OPTS
+        value: $(JAVA_OPTS)
+    memoryLimit: 512Mi
+    mountSources: true
+    volumes:
+      - name: m2
+        containerPath: /home/jboss/.m2
+commands:
+  -
+    name: maven build
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "mvn clean install"
+        workdir: ${CHE_PROJECTS_ROOT}/console-java-simple
+  -
+    name: maven build and run
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "mvn clean install && java -jar ./target/*.jar"
+        workdir: ${CHE_PROJECTS_ROOT}/console-java-simple
+  -
+    name: dependency analysis
+    actions:
+      -
+        type: exec
+        component: maven
+        command: "${HOME}/stack-analysis.sh -f ${CHE_PROJECTS_ROOT}/console-java-simple/pom.xml -p ${CHE_PROJECTS_ROOT}/console-java-simple"

--- a/dependencies/che-devfile-registry/devfiles/java-maven/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/java-maven/meta.yaml
@@ -1,0 +1,6 @@
+---
+displayName: Java Maven
+description: Java Stack with OpenJDK 8 and Maven 3.5.4
+tags: ["Java", "OpenJDK", "Maven"]
+icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/ide/codeready-ide-stacks/src/main/resources/stacks-images/type-java.svg
+globalMemoryLimit: 2674Mi


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

Adds several devfiles:
-  dotnet with [dotnet-web-simple](https://github.com/che-samples/dotnet-web-simple) application
-  java-maven with [console-java-simple](https://github.com/che-samples/console-java-simple.git) application
-  java-eap-maven with [kitchensink-example](https://github.com/che-samples/kitchensink-example.git)
- java-eap-thorntail with [rest-http-redhat](https://github.com/thorntail-examples/rest-http-redhat) application