### PR TITLE
Remove samples.json logic.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -266,12 +266,6 @@ init() {
     rm -rf "${CHE_DATA}"/stacks
   fi
 
-  # replace samples.json each run to make sure that we are using corrent samples from the assembly.
-  # also it allows users to store their own samples which should not be touched by us.
-  mkdir -p "${CHE_DATA}"/templates
-  rm -rf "${CHE_DATA}"/templates/samples.json
-  cp -rf "${CHE_HOME}"/templates/* "${CHE_DATA}"/templates
-
   # A che property, which names the Docker network used for che + ws to communicate
   if [ -z "$CHE_DOCKER_NETWORK" ]; then
     NETWORK_NAME="bridge"


### PR DESCRIPTION
Same change happened in upstream in commit https://github.com/eclipse/che/commit/79c6ec0703fb5c00458e2fa00b4df9f586c0c5a9#diff-1da4013f60e1b92b5613cf9680423a88

Without this change, latest codeready server fails with 
```
Using embedded assembly...
cp: cannot stat '/home/jboss/codeready/templates/*': No such file or directory
```

Signed-off-by: Radim Hopp <rhopp@redhat.com>