### PR TITLE
Add support for caching prebuilt vsix extensions

### DIFF
--- a/dependencies/che-plugin-registry/Jenkinsfile-all
+++ b/dependencies/che-plugin-registry/Jenkinsfile-all
@@ -1,0 +1,71 @@
+#!/usr/bin/env groovy
+
+// build params
+//BranchToBuildCRW - branch for crw plugin registry
+
+timeout(120) {
+    node {
+        cleanWs()
+        stage 'build extensions'
+
+        // key value map for build jobs, where key is extension location in the registry
+        def jobs = [:]
+
+        checkout([$class: 'GitSCM',
+            branches: [[name: "${branchToBuildCRW}"]],
+            doGenerateSubmoduleConfigurations: false,
+            poll: true,
+            extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: "crw"]],
+            submoduleCfg: [],
+            userRemoteConfigs: [[url: "https://github.com/redhat-developer/codeready-workspaces.git"]]])
+
+        def extensionFiles = findFiles(glob: 'crw/dependencies/che-plugin-registry/v3/plugins/**/meta.yaml')
+
+        extensionFiles.each { extensionFile ->
+            def extensionYaml = readYaml file: extensionFile.getPath()
+            if (!extensionYaml.spec.extensions) {
+                echo "extensions are not present in plugin ${extensionFile.getPath()} skipping"
+                return
+            }
+            def extensionPath = extensionYaml.spec.extensions[0]
+            echo "processing extension ${extensionPath}"
+            if (extensionPath.contains("marketplace.visualstudio.com")) {
+                def registryLocation = extensionPath.split("//")[1]
+                echo "selected extension ${registryLocation}"
+
+                // since there may be multiple plugins pointing to the same extension URL
+                // we just need to buld them once
+                if (jobs.containsKey(registryLocation)) {
+                    echo "duplicated plugin ${registryLocation} omitted"
+                    return
+                }
+
+                def repository = extensionYaml.repository
+                echo "${repository}"
+                // parse extension URL to get the version of the plugin, which should be second to last
+                def extensionName = extensionYaml.name
+
+                // infering the branch from the version of the plugin in the extension URL
+                // and prefixing with 'v'
+                def branch = "v" + extensionPath.split("${extensionName}/")[1].split("/vspackage")[0]
+
+                echo "${branch}"
+
+
+                def buildjob = build job: 'vscode-extensions-packaging', parameters: [ string(name: 'extensionPath', value: repository), string(name: 'branchToBuildPlugin', value: branch) ]
+                jobs.put(registryLocation, buildjob)
+            }
+        }
+        sh "mkdir vsix"
+        jobs.each { fileLocation, job ->
+            echo "archiving artifact at ${fileLocation}"
+            copyArtifacts(projectName: 'vscode-extensions-packaging', selector: specific("${job.number}"), target: "vsix/" + fileLocation)
+        }
+
+        sh "tar -czvf vsix.tar.gz vsix"
+
+        // TODO deploy artifact to pkgs.devel?
+
+        archiveArtifacts artifacts: '*.tar.gz', fingerprint: true
+    }
+}

--- a/dependencies/che-plugin-registry/Jenkinsfile-single
+++ b/dependencies/che-plugin-registry/Jenkinsfile-single
@@ -1,0 +1,35 @@
+#!/usr/bin/env groovy
+
+// build params
+//branchToBuildPlugin - extension branch (default master)
+//extensionPath - URL to extension repo
+//node - node version
+
+def installNPM(){
+    def nodeHome = tool 'nodejs-10.15.3'
+    env.PATH="${nodeHome}/bin:${env.PATH}"
+    sh "node --version; npm --version"
+}
+
+
+timeout(120) {
+    node("${node}"){ stage "Build ${extensionPath}"
+        cleanWs()
+        def extensionFolder = "${extensionPath}".substring("${extensionPath}".lastIndexOf('/') + 1);
+
+        echo "${extensionFolder}"
+
+        checkout([$class: 'GitSCM',
+                  branches: [[name: "${branchToBuildPlugin}"]],
+                  doGenerateSubmoduleConfigurations: false,
+                  poll: true,
+                  extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: "${extensionFolder}"]],
+                  submoduleCfg: [],
+                  userRemoteConfigs: [[url: "${extensionPath}"]]])
+
+        installNPM()
+        sh "cd ${extensionFolder} && sudo npm install -g vsce && sudo npm install -g gulp && npm install && vsce package"
+        sh "mv **/*.vsix ."
+        archiveArtifacts artifacts: '*.vsix', fingerprint: true
+    }
+}

--- a/dependencies/che-plugin-registry/build/scripts/cache_artifacts.sh
+++ b/dependencies/che-plugin-registry/build/scripts/cache_artifacts.sh
@@ -23,12 +23,43 @@ fi
 RESOURCES_DIR="${1}/resources/"
 TEMP_DIR="${1}/extensions_temp/"
 
+PREBUILT_VSIX_ARCHIVE_DIR_NAME="${1}/vsix"
+
+if [ -f "${PREBUILT_VSIX_ARCHIVE_DIR_NAME}.tar.gz" ]; then
+echo "found ${PREBUILT_VSIX_ARCHIVE_DIR_NAME}.tar.gz, unpacking"
+  tar -zxvf ${PREBUILT_VSIX_ARCHIVE_DIR_NAME}.tar.gz -C ${1}
+  rm -fr ${PREBUILT_VSIX_ARCHIVE_DIR_NAME}.tar.gz
+  readarray -d '' prebuilt_extensions < <(find "${PREBUILT_VSIX_ARCHIVE_DIR_NAME}" -name '*.vsix' -print0)
+fi
+
 mkdir -p "${RESOURCES_DIR}" "${TEMP_DIR}"
 for extension in $(yq -r '.spec.extensions[]?' "${metas[@]}" | sort | uniq); do
   echo -en "Caching extension ${extension}\n    "
-  # Workaround for getting filenames through content-disposition: copy to temp
-  # dir and read filename before moving to /resources.
-  wget -P "${TEMP_DIR}" -nv --content-disposition "${extension}"
+
+  # Before attempting to download, check if we already have this file in supplied prebuilt plugins
+  # archive. If found, skip the download
+  for plugin_file_path in "${prebuilt_extensions[@]}"; do
+    # strip root directory from path on filesystem to match it with extension URL
+    rel_plugin_file_path=${plugin_file_path#${PREBUILT_VSIX_ARCHIVE_DIR_NAME}/}
+    rel_plugin_file_path=${rel_plugin_file_path%/*.vsix}
+
+    extension_location=${extension#*//}
+
+    if [[ ${rel_plugin_file_path} == ${extension_location} ]]; then
+      matched_plugin_path=${plugin_file_path}
+      echo "found prebuilt extension: ${matched_plugin_path}    "
+      break
+    fi
+  done
+
+  if [[ ! -z "$matched_plugin_path" ]]; then
+    mv "${matched_plugin_path}" ${TEMP_DIR}
+  else
+    # Workaround for getting filenames through content-disposition: copy to temp
+    # dir and read filename before moving to /resources.
+    wget -P "${TEMP_DIR}" -nv --content-disposition "${extension}"
+  fi
+
   file=$(find "${TEMP_DIR}" -type f)
   filename=$(basename "${file}")
 


### PR DESCRIPTION
This PR adds the ability to provide during the build of plugin registry an archive with .vsix extensions, so that during the caching artifacts stage it would reuse them, instead of downloading by extension URL. For this to work, an archive `vsix.tar.gz` must be placed in a `/v3` directory before the build of plugin registry, and it must contain a plugin in a folder structure, following the extension URL path (including the `vsix` root directory of tarball)

For example, a `vsix.tar.gz` with a following extension in it:
```
vsix/marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/node-debug2/1.33.0/vspackage/node-debug2-1.33.0.vsix
```

Would have this extension reused for plugins with following extension URL
```
meta.yaml:
...
  extensions:
  - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/node-debug2/1.33.0/vspackage
```

So this feature would allow avoiding attempting to download of any plugins, that would rather need to be rebuilt and provided by us.

PR comes with new Jenkins Jobs
- Jenkinsfile-all - main job, that fetches plugin registry, looks up the vsix. extensions URL (currently only those that are hosted on "marketplace.visualstudio.com", builds them and collects in a tarball vsix.tar.gz
- Jenkinsfile-single - sub-job, that packages a vsix extensions from given repository


 