### PR TITLE
Change image for dependency-analytics

### DIFF
--- a/dependencies/che-plugin-registry/v3/plugins/redhat/dependency-analytics/0.0.13/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/dependency-analytics/0.0.13/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: '2019-09-12'
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-dependency-analytics-0.0.13:next"
+    - image: "quay.io/crw/stacks-java-rhel8:2.0"
       name: dependency-analytics
       memoryLimit: "512Mi"
   extensions:


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

Sets `quay.io/crw/stacks-java-rhel8:2.0` image for dependency-analytics plugin