### PR TITLE
[7.3.1] when we switch to new...

### DIFF
--- a/dependencies/che-plugin-registry/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: "quay.io/crw/theia-endpoint-rhel8:2.0"
+  - image: "quay.io/crw/stacks-node-rhel8:2.0"
     name: vscode-typescript
     memoryLimit: '512Mi'
   extensions:

--- a/dependencies/che-plugin-registry/v3/plugins/eclipse/che-theia/7.3.0/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/eclipse/che-theia/7.3.0/meta.yaml
@@ -67,3 +67,15 @@ spec:
          - exposedPort: 13132
          - exposedPort: 13133
      memoryLimit: "512M"
+  initContainers:
+  - name: remote-runtime-injector
+    image: quay.io/crw/theia-endpoint:2.0
+    volumes:
+      - mountPath: "/remote-endpoint"
+        name: remote-endpoint
+        ephemeral: true
+    env:
+      - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+        value: /remote-endpoint/plugin-remote-endpoint
+      - name: REMOTE_ENDPOINT_VOLUME_NAME
+        value: remote-endpoint

--- a/dependencies/che-plugin-registry/v3/plugins/ms-vscode/node-debug2/1.33.0/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/ms-vscode/node-debug2/1.33.0/meta.yaml
@@ -13,7 +13,7 @@ category: Debugger
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: "quay.io/crw/theia-endpoint-rhel8:2.0"
+  - image: "quay.io/crw/stacks-node-rhel8:2.0"
     name: vscode-node-debug
     memoryLimit: '512Mi'
   extensions:

--- a/dependencies/che-plugin-registry/v3/plugins/redhat/vscode-yaml/0.4.0/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/vscode-yaml/0.4.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-19"
 spec:
   containers:
-    - image: "quay.io/crw/theia-endpoint-rhel8:2.0"
+    - image: "quay.io/crw/stacks-node-rhel8:2.0"
       name: vscode-yaml
       memoryLimit: "256Mi"
   extensions:


### PR DESCRIPTION
[7.3.1] when we switch to new endpoint-binary, use stacks-node instead of theia-endpoint

Change-Id: Ifff6f211acbc435aee6a29e2678e38152cf69037
Signed-off-by: nickboldt <nboldt@redhat.com>