### PR TITLE
Fix launching remote plugins according to use latest che-plugin-broker.

### DIFF
--- a/dependencies/che-plugin-registry/v3/plugins/che-incubator/cpptools/0.1/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/che-incubator/cpptools/0.1/meta.yaml
@@ -15,6 +15,10 @@ spec:
     - image: "quay.io/crw/stacks-cpp-rhel8:2.0"
       name: cpp-plugins
       memoryLimit: '512Mi'
+      args:
+        - sh
+        - -c
+        - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
   extensions:
     - https://github.com/che-incubator/che-cpptools/releases/download/v1.0/cdt-gdb-vscode-0.0.90.vsix
     - https://github.com/che-incubator/che-cpptools/releases/download/v1.0/cdt-vscode-0.0.7.vsix

--- a/dependencies/che-plugin-registry/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
@@ -15,5 +15,9 @@ spec:
   - image: "quay.io/crw/stacks-node-rhel8:2.0"
     name: vscode-typescript
     memoryLimit: '512Mi'
+    args:
+      - sh
+      - -c
+      - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
   extensions:
   - https://github.com/che-incubator/ms-code.typescript/releases/download/v1.35.1/che-typescript-language-1.35.1.vsix

--- a/dependencies/che-plugin-registry/v3/plugins/ms-python/python/2019.5.18875/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/ms-python/python/2019.5.18875/meta.yaml
@@ -16,5 +16,9 @@ spec:
   - image: "quay.io/crw/stacks-python-rhel8:2.0"
     name: vscode-python
     memoryLimit: '512Mi'
+    args:
+      - sh
+      - -c
+      - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
   extensions:
   - https://github.com/Microsoft/vscode-python/releases/download/2019.5.18875/ms-python-release.vsix

--- a/dependencies/che-plugin-registry/v3/plugins/ms-vscode/go/0.11.4/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/ms-vscode/go/0.11.4/meta.yaml
@@ -15,6 +15,10 @@ spec:
     - image: "quay.io/crw/stacks-golang-rhel8:2.0"
       name: vscode-go
       memoryLimit: '512Mi'
+      args:
+        - sh
+        - -c
+        - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
       env:
       - name: GOPATH
         value: /projects/.che/gopath:$(CHE_PROJECTS_ROOT)

--- a/dependencies/che-plugin-registry/v3/plugins/ms-vscode/node-debug2/1.33.0/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/ms-vscode/node-debug2/1.33.0/meta.yaml
@@ -16,5 +16,9 @@ spec:
   - image: "quay.io/crw/stacks-node-rhel8:2.0"
     name: vscode-node-debug
     memoryLimit: '512Mi'
+    args:
+      - sh
+      - -c
+      - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
   extensions:
   - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/node-debug2/1.33.0/vspackage

--- a/dependencies/che-plugin-registry/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.5/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.5/meta.yaml
@@ -15,6 +15,10 @@ spec:
   - image: "quay.io/crw/stacks-dotnet-rhel8:2.0"
     name: theia-omnisharp
     memoryLimit: "1024Mi"
+    args:
+      - sh
+      - -c
+      - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
     volumes:
     - mountPath: "/home/jboss/.nuget"
       name: nuget

--- a/dependencies/che-plugin-registry/v3/plugins/redhat/dependency-analytics/0.0.13/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/dependency-analytics/0.0.13/meta.yaml
@@ -15,5 +15,9 @@ spec:
     - image: "quay.io/crw/stacks-java-rhel8:2.0"
       name: dependency-analytics
       memoryLimit: "512Mi"
+      args:
+        - sh
+        - -c
+        - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
   extensions:
     - https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.0.13/redhat.fabric8-analytics-0.0.13.vsix

--- a/dependencies/che-plugin-registry/v3/plugins/redhat/java/0.50.0/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/java/0.50.0/meta.yaml
@@ -16,6 +16,10 @@ spec:
   - image: "quay.io/crw/stacks-java-rhel8:2.0"
     name: vscode-java
     memoryLimit: "1500Mi"
+    args:
+      - sh
+      - -c
+      - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
     volumes:
     - mountPath: "/home/theia/.m2"
       name: m2

--- a/dependencies/che-plugin-registry/v3/plugins/redhat/java8/0.50.0/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/java8/0.50.0/meta.yaml
@@ -16,6 +16,10 @@ spec:
   - image: "quay.io/crw/stacks-java-rhel8:2.0"
     name: vscode-java
     memoryLimit: "1500Mi"
+    args:
+      - sh
+      - -c
+      - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
     volumes:
     - mountPath: "/home/theia/.m2"
       name: m2

--- a/dependencies/che-plugin-registry/v3/plugins/redhat/php-debugger/1.13.0/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/php-debugger/1.13.0/meta.yaml
@@ -14,5 +14,9 @@ spec:
   containers:
     - image: "quay.io/crw/stacks-php-rhel8:2.0"
       name: php-debugger
+      args:
+        - sh
+        - -c
+        - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
   extensions:
     - https://github.com/felixfbecker/vscode-php-debug/releases/download/v1.13.0/php-debug.vsix

--- a/dependencies/che-plugin-registry/v3/plugins/redhat/php/1.0.13/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/php/1.0.13/meta.yaml
@@ -15,5 +15,9 @@ spec:
     - image: "quay.io/crw/stacks-php-rhel8:2.0"
       name: php-intelephense
       memoryLimit: "1000Mi"
+      args:
+        - sh
+        - -c
+        - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
   extensions:
     - https://github.com/che-incubator/vscode-intelephense/releases/download/v1.0.13/bmewburn.vscode-intelephense-client-1.0.13.vsix

--- a/dependencies/che-plugin-registry/v3/plugins/redhat/vscode-apache-camel/0.0.18/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/vscode-apache-camel/0.0.18/meta.yaml
@@ -15,5 +15,9 @@ spec:
   - image: "quay.io/crw/stacks-java-rhel8:2.0"
     name: vscode-apache-camel
     memoryLimit: "512Mi"
+    args:
+      - sh
+      - -c
+      - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
   extensions:
   - https://download.jboss.org/jbosstools/vscode/stable/vscode-apache-camel/vscode-apache-camel-0.0.18-67.vsix

--- a/dependencies/che-plugin-registry/v3/plugins/redhat/vscode-wsdl2rest/0.0.9/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/vscode-wsdl2rest/0.0.9/meta.yaml
@@ -14,5 +14,9 @@ spec:
   containers:
     - image: "quay.io/crw/stacks-java-rhel8:2.0"
       memoryLimit: "256Mi"
+      args:
+        - sh
+        - -c
+        - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
   extensions:
     - https://download.jboss.org/jbosstools/vscode/stable/vscode-wsdl2rest/vscode-wsdl2rest-0.0.9-16.vsix

--- a/dependencies/che-plugin-registry/v3/plugins/redhat/vscode-xml/0.9.1/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/vscode-xml/0.9.1/meta.yaml
@@ -15,5 +15,9 @@ spec:
     - image: "quay.io/crw/stacks-java-rhel8:2.0"
       name: vscode-xml
       memoryLimit: "768Mi"
+      args:
+        - sh
+        - -c
+        - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
   extensions:
     - https://github.com/redhat-developer/vscode-xml/releases/download/0.9.1/redhat.vscode-xml-0.9.1.vsix

--- a/dependencies/che-plugin-registry/v3/plugins/redhat/vscode-yaml/0.4.0/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/vscode-yaml/0.4.0/meta.yaml
@@ -15,5 +15,9 @@ spec:
     - image: "quay.io/crw/stacks-node-rhel8:2.0"
       name: vscode-yaml
       memoryLimit: "256Mi"
+      args:
+        - sh
+        - -c
+        - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
   extensions:
     - https://github.com/redhat-developer/vscode-yaml/releases/download/0.4.0/redhat.vscode-yaml-0.4.0.vsix


### PR DESCRIPTION
### Referenced issue:
https://issues.jboss.org/browse/CRW-493

### What does this pull request do
Change plugin meta.yaml#spec#containers#container#args(it is Dockerfile#CMD) to start remote plugin endpoint binary.  

Notice:
We don't touch meta.yaml#spec#containers#container#command (it is Dockerfile#ENTRYPOINT), so entrypoint.sh scripts defined in the Dockerfile#ENTRYPOINT should work fine.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>