### PR TITLE
Workaround for CRW-494 - disable pushing logs to server in init broker

### DIFF
--- a/dependencies/che-pluginbroker/build/init/rhel.Dockerfile
+++ b/dependencies/che-pluginbroker/build/init/rhel.Dockerfile
@@ -16,6 +16,13 @@ ENV PATH=/opt/rh/go-toolset-1.11/root/usr/bin:$PATH \
 USER root
 WORKDIR /go/src/github.com/eclipse/che-plugin-broker/brokers/init/cmd/
 COPY . /go/src/github.com/eclipse/che-plugin-broker/
+# Workaround for CRW-494 - disable websocket communication in init broker
+RUN LN_START="$(grep -n 'cfg.DisablePushingToEndpoint' main.go | cut -f 1 -d ':')"; \
+    LN_END="$((LN_START + 3))"; \
+    sed -i "${LN_START},${LN_END}s|^|//|g" main.go && \
+    echo "Updated main.go" && cat main.go
+# End Workaround for CRW-494
+
 RUN adduser appuser && \
     CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -installsuffix cgo -o init-plugin-broker main.go
 


### PR DESCRIPTION
This PR is a workaround for https://issues.jboss.org/browse/CRW-494 pending merge of PRs https://github.com/eclipse/che/pull/15263, https://github.com/eclipse/che/pull/15264. 

During the docker build of the init container, we comment out the lines that attempt to connect to the server via websocket. Since upstream Che 7.3.2 does not provision proxy settings for the init container, connecting fails and this blocks workspace start. The only impact of removing these lines is that workspace start does not see the log message
```
Cleaning /plugins dir
```