### PR TITLE
Apply patch to fix proxy issue from upstream Che during build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,6 +186,13 @@ timeout(180) {
 			cat che/dashboard/src/assets/branding/branding.css
 		'''
 
+		sh '''#!/bin/bash -xe
+			cp ./patches/0001-Provision-proxy-settings-on-init-containers.patch ${CHE_PATH}
+			pushd ${CHE_PATH} > /dev/null
+			git am < 0001-Provision-proxy-settings-on-init-containers.patch
+			popd ${CHE_PATH} > /dev/null
+		'''
+
 		sh "mvn clean install ${MVN_FLAGS} -P native -f ${CHE_path}/pom.xml ${MVN_EXTRA_FLAGS}"
 		stash name: 'stashChe', includes: findFiles(glob: '.repository/**').join(", ")
 		archiveArtifacts fingerprint: false, artifacts:"**/*.log, **/${CHE_path}/pom.xml, **/${CHE_path}/assembly/assembly-main/pom.xml, **/${CHE_path}/assembly/assembly-main/src/assembly/assembly.xml"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,10 +187,10 @@ timeout(180) {
 		'''
 
 		sh '''#!/bin/bash -xe
-			cp ./patches/0001-Provision-proxy-settings-on-init-containers.patch ${CHE_PATH}
-			pushd ${CHE_PATH} > /dev/null
+			cp ./patches/0001-Provision-proxy-settings-on-init-containers.patch ${CHE_path}
+			pushd ${CHE_path} > /dev/null
 			git am < 0001-Provision-proxy-settings-on-init-containers.patch
-			popd ${CHE_PATH} > /dev/null
+			popd ${CHE_path} > /dev/null
 		'''
 
 		sh "mvn clean install ${MVN_FLAGS} -P native -f ${CHE_path}/pom.xml ${MVN_EXTRA_FLAGS}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,8 +187,8 @@ timeout(180) {
 		'''
 
 		sh '''#!/bin/bash -xe
-			cp ./patches/0001-Provision-proxy-settings-on-init-containers.patch ''' + ${CHE_path} + '''
-			pushd ''' + ${CHE_path} + ''' > /dev/null
+			cp ./patches/0001-Provision-proxy-settings-on-init-containers.patch ''' + CHE_path + '''
+			pushd ''' + CHE_path + ''' > /dev/null
 			git am < 0001-Provision-proxy-settings-on-init-containers.patch
 			popd > /dev/null
 		'''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,10 +187,10 @@ timeout(180) {
 		'''
 
 		sh '''#!/bin/bash -xe
-			cp ./patches/0001-Provision-proxy-settings-on-init-containers.patch ${CHE_path}
-			pushd ${CHE_path} > /dev/null
+			cp ./patches/0001-Provision-proxy-settings-on-init-containers.patch ''' + ${CHE_path} + '''
+			pushd ''' + ${CHE_path} + ''' > /dev/null
 			git am < 0001-Provision-proxy-settings-on-init-containers.patch
-			popd ${CHE_path} > /dev/null
+			popd > /dev/null
 		'''
 
 		sh "mvn clean install ${MVN_FLAGS} -P native -f ${CHE_path}/pom.xml ${MVN_EXTRA_FLAGS}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,7 +111,7 @@ def CRW_path = "codeready-workspaces"
 def VER_CRW = "VER_CRW"
 def SHA_CRW = "SHA_CRW"
 timeout(120) {
-	node("${node}"){ stage "Get ${CRW_path} version"
+	node("${node}"){ stage "Get ${CRW_path} version and patches"
 		cleanWs()
 		// for private repo, use checkout(credentialsId: 'devstudio-release')
 		if (env.ghprbPullId && env.ghprbPullId?.trim()) { 
@@ -133,6 +133,7 @@ timeout(120) {
 		}
 		VER_CRW = sh(returnStdout:true,script:"egrep \"<version>\" ${CRW_path}/pom.xml|head -2|tail -1|sed -e \"s#.*<version>\\(.\\+\\)</version>#\\1#\"").trim()
 		SHA_CRW = sh(returnStdout:true,script:"cd ${CRW_path}/ && git rev-parse --short=4 HEAD").trim()
+		stash name: 'stashCRWPatches', includes: findFiles(glob: CRW_path + '/patches/**').join(", ")
 	}
 }
 
@@ -185,9 +186,9 @@ timeout(180) {
 				https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${rawBranch}/assembly/codeready-workspaces-assembly-dashboard-war/src/main/webapp/assets/branding/branding-crw.css
 			cat che/dashboard/src/assets/branding/branding.css
 		'''
-
+		unstash 'stashCRWPatches'
 		sh '''#!/bin/bash -xe
-			cp ./patches/0001-Provision-proxy-settings-on-init-containers.patch ''' + CHE_path + '''
+			cp ''' + CRW_path + '''/patches/0001-Provision-proxy-settings-on-init-containers.patch ''' + CHE_path + '''
 			pushd ''' + CHE_path + ''' > /dev/null
 			git am < 0001-Provision-proxy-settings-on-init-containers.patch
 			popd > /dev/null

--- a/patches/0001-Provision-proxy-settings-on-init-containers.patch
+++ b/patches/0001-Provision-proxy-settings-on-init-containers.patch
@@ -1,0 +1,102 @@
+From 01f1d71dda843f2c3b7b89c3dd3ab6364b2b3a7f Mon Sep 17 00:00:00 2001
+From: Angel Misevski <amisevsk@redhat.com>
+Date: Wed, 20 Nov 2019 17:46:49 -0500
+Subject: [PATCH] Provision proxy settings on init containers
+
+Signed-off-by: Angel Misevski <amisevsk@redhat.com>
+---
+ .../provision/ProxySettingsProvisioner.java   |  7 +++-
+ .../ProxySettingsProvisionerTest.java         | 35 ++++++++++++++++++-
+ 2 files changed, 40 insertions(+), 2 deletions(-)
+
+diff --git a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ProxySettingsProvisioner.java b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ProxySettingsProvisioner.java
+index c95d409cfe..397f9c2905 100644
+--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ProxySettingsProvisioner.java
++++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ProxySettingsProvisioner.java
+@@ -16,6 +16,7 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.
+ import io.fabric8.kubernetes.api.model.EnvVar;
+ import java.util.HashMap;
+ import java.util.Map;
++import java.util.stream.Stream;
+ import javax.inject.Inject;
+ import javax.inject.Named;
+ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+@@ -68,7 +69,11 @@ public class ProxySettingsProvisioner implements ConfigurationProvisioner {
+           // JWTProxy container doesn't need proxy settings since it never does any outbound
+           // requests, and setting of it may fail accessing internal addresses.
+           .filter(entry -> !entry.getKey().equals(JWT_PROXY_POD_NAME))
+-          .flatMap(entry -> entry.getValue().getSpec().getContainers().stream())
++          .flatMap(
++              entry ->
++                  Stream.concat(
++                      entry.getValue().getSpec().getContainers().stream(),
++                      entry.getValue().getSpec().getInitContainers().stream()))
+           .forEach(
+               container ->
+                   proxyEnvVars.forEach((k, v) -> container.getEnv().add(new EnvVar(k, v, null))));
+diff --git a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ProxySettingsProvisionerTest.java b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ProxySettingsProvisionerTest.java
+index ce38a373b2..311a1513d4 100644
+--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ProxySettingsProvisionerTest.java
++++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ProxySettingsProvisionerTest.java
+@@ -25,9 +25,11 @@ import io.fabric8.kubernetes.api.model.EnvVar;
+ import io.fabric8.kubernetes.api.model.Pod;
+ import io.fabric8.kubernetes.api.model.PodBuilder;
+ import java.util.ArrayList;
++import java.util.Arrays;
+ import java.util.HashMap;
+ import java.util.List;
+ import java.util.Map;
++import java.util.stream.Stream;
+ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+ import org.mockito.Mock;
+@@ -59,7 +61,7 @@ public class ProxySettingsProvisionerTest {
+   public void shouldApplyProxySettingsToAllContainers() throws Exception {
+ 
+     Map<String, Pod> pods = new HashMap<>();
+-    pods.put("pod1", buildPod("pod1", buildContainers(2)));
++    Pod pod1 = pods.put("pod1", buildPod("pod1", buildContainers(2)));
+     pods.put("pod2", buildPod("pod2", buildContainers(3)));
+ 
+     KubernetesEnvironment k8sEnv = KubernetesEnvironment.builder().setPods(pods).build();
+@@ -109,6 +111,37 @@ public class ProxySettingsProvisionerTest {
+                             .contains(new EnvVar(NO_PROXY, NO_PROXY_VALUE, null))));
+   }
+ 
++  @Test
++  public void shouldApplyProxySettingsToInitContainers() throws Exception {
++    Map<String, Pod> pods = new HashMap<>();
++    Pod pod1 = buildPod("pod1", buildContainers(3));
++    pod1.getSpec().setInitContainers(Arrays.asList(buildContainers(2)));
++    pods.put("pod1", pod1);
++
++    KubernetesEnvironment k8sEnv = KubernetesEnvironment.builder().setPods(pods).build();
++    provisioner.provision(k8sEnv, runtimeId);
++
++    assertTrue(
++        k8sEnv
++            .getPodsData()
++            .values()
++            .stream()
++            .flatMap(
++                pod ->
++                    Stream.concat(
++                        pod.getSpec().getContainers().stream(),
++                        pod.getSpec().getInitContainers().stream()))
++            .allMatch(
++                container ->
++                    container.getEnv().contains(new EnvVar(HTTP_PROXY, HTTP_PROXY_VALUE, null))
++                        && container
++                            .getEnv()
++                            .contains(new EnvVar(HTTPS_PROXY, HTTPS_PROXY_VALUE, null))
++                        && container
++                            .getEnv()
++                            .contains(new EnvVar(NO_PROXY, NO_PROXY_VALUE, null))));
++  }
++
+   private Pod buildPod(String podName, Container... containers) {
+     return new PodBuilder()
+         .withNewMetadata()
+-- 
+2.21.0
+


### PR DESCRIPTION
Apply patch derived from https://github.com/eclipse/che/pull/15264 to Che during build to workaround https://github.com/eclipse/che/issues/15265 ([CRW-494](https://issues.jboss.org/browse/CRW-494))

I can't test this change directly.

If merged, this PR makes https://github.com/redhat-developer/codeready-workspaces/pull/201/ obsolete.