### PR TITLE
Remove MAVEN_CONFIG env from maven based containers

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/devfile.yaml
@@ -17,8 +17,6 @@ components:
     alias: maven
     image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8:2.0
     env:
-      - name: MAVEN_CONFIG
-        value: /home/jboss/.m2
       - name: MAVEN_OPTS
         value: "-Xmx200m -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"
     memoryLimit: 512Mi

--- a/dependencies/che-devfile-registry/devfiles/01_java-eap-thorntail/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/01_java-eap-thorntail/devfile.yaml
@@ -17,8 +17,6 @@ components:
     alias: maven
     image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8:2.0
     env:
-      - name: MAVEN_CONFIG
-        value: /home/jboss/.m2
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"
       - name: MAVEN_OPTS

--- a/dependencies/che-devfile-registry/devfiles/02_java-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-maven/devfile.yaml
@@ -17,8 +17,6 @@ components:
     alias: maven
     image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8:2.0
     env:
-      - name: MAVEN_CONFIG
-        value: /home/jboss/.m2
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"
       - name: MAVEN_OPTS


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

It is unnecessary to have `MAVEN_CONFIG` for `registry.redhat.io/codeready-workspaces/stacks-java-rhel8:2.0`.  In some cases it could be erroneously to have `MAVEN_CONFIG`, for example, if user  uses `mvnw`.

For more information take a look at https://github.com/eclipse/che/issues/13926 and https://github.com/eclipse/che-devfile-registry/pull/160