### PR TITLE
CRW-594 switch to use...

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/devfile.yaml
@@ -42,7 +42,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "mvn clean install && cp target/*.war /opt/eap/standalone/deployments/ROOT.war && export JAVA_OPTS_APPEND=-Dsun.util.logging.disableCallerCheck=true && /opt/eap/bin/standalone.sh -b 0.0.0.0 --debug 8000"
+        command: "mvn clean install && cp target/*.war /opt/eap/standalone/deployments/ROOT.war && export JAVA_OPTS_APPEND=-Dsun.util.logging.disableCallerCheck=true && /opt/eap/bin/openshift-launch.sh -b 0.0.0.0 --debug 8000"
         workdir: ${CHE_PROJECTS_ROOT}/kitchensink-example
   -
     name: copy war


### PR DESCRIPTION
CRW-594 switch to use /opt/eap/bin/openshift-launch.sh instead of /opt/eap/bin/standalone.sh (prepare for EAP 7.3)

Change-Id: If5afd113114b7558d48e31c22300fe72a2f603b9
Signed-off-by: nickboldt <nboldt@redhat.com>