### PR TITLE
CRW-585 switch to golangci-lint (depends on...

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/05_go/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_go/devfile.yaml
@@ -15,6 +15,9 @@ components:
   id: ms-vscode/go/latest
   alias: go-plugin
   memoryLimit: 512Mi
+  preferences:
+    go.lintTool: 'golangci-lint'
+    go.lintFlags: '--fast'
 -
   type: dockerimage
   image: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8:2.1


### PR DESCRIPTION
CRW-585 switch to golangci-lint (depends on new golang sidecar image)

Change-Id: Id3ce019083a5b86234baacec545ee63c492d97b0
Signed-off-by: nickboldt <nboldt@redhat.com>