### PR TITLE
Add args into quarkus plugin

### DIFF
--- a/dependencies/che-plugin-registry/v3/plugins/redhat/quarkus-java11/1.2.0/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/quarkus-java11/1.2.0/meta.yaml
@@ -15,6 +15,10 @@ spec:
     - image: "quay.io/crw/plugin-java11-rhel8:2.1"
       name: vscode-quarkus
       memoryLimit: "3500Mi"
+      args:
+        - sh
+        - -c
+        - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
       volumes:
       - mountPath: "/home/jboss/.m2"
         name: m2


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

Adds args into quarkus plug-in: 
```yaml
      args:
        - sh
        - -c
        - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
```
cc @nickboldt 