### PR TITLE
CRW-590: enable offline devfiles registry build

### DIFF
--- a/dependencies/che-devfile-registry/Jenkinsfile
+++ b/dependencies/che-devfile-registry/Jenkinsfile
@@ -125,15 +125,31 @@ cp -f ${SOURCEDOCKERFILE} ${WORKSPACE}/target/Dockerfile
 CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/VERSION`
 # apply patches to transform CRW upstream to pkgs.devel version
 sed -i ${WORKSPACE}/target/Dockerfile \
-  -e "s/ *COPY\\(.\\+content_set.\\+\\)/# COPY\\1/g" \
-  -e "s/^# *COPY root/COPY root/g" \
-  -e "s%^FROM registry.access.redhat.com/%FROM %g" \
-  -e "s%^FROM registry.redhat.io/%FROM %g" \
-  -e "s%^FROM builder%# FROM builder%g" \
-  -e "s%^FROM registry %# FROM registry %g" \
-  -e "s%^COPY --from=offline-builder%# COPY --from=offline-builder%g"
-
-cat ${WORKSPACE}/target/Dockerfile
+  `# Replace image used for registry with rhel8/httpd-24` \
+  -Ee 's|^ *FROM registry.access.redhat.com/.* AS registry|# &|' \
+  -Ee 's|# *(FROM.*rhel8/httpd.*)|\1|' \
+  `# Strip registry from image references` \
+  -Ee 's|FROM registry.access.redhat.com/|FROM |' \
+  -Ee 's|FROM registry.redhat.io/|FROM |' \
+  `# Set arg options: enable USE_DIGESTS and disable BOOTSTRAP` \
+  -Ee 's|ARG USE_DIGESTS=.*|ARG USE_DIGESTS=true|' \
+  -Ee 's|ARG BOOTSTRAP=.*|ARG BOOTSTRAP=false|' \
+  `# Enable offline build - copy in built binaries` \
+  -Ee 's|# (COPY root-local.tgz)|\1|' \
+  -Ee 's|^ *COPY .*content_sets.*|# &|' \
+  `# Comment out PATCHED_* args from build and disable update_devfile_patched_image_tags.sh` \
+  -Ee 's|^ *ARG PATCHED.*|# &|' \
+  -Ee '/^ *RUN TAG/,+3 s|.*|# &| ' \
+  `# Disable intermediate build targets` \
+  -Ee 's|^ *FROM registry AS offline-registry|# &|' \
+  -Ee '/^ *FROM builder AS offline-builder/,+3 s|.*|# &|' \
+  -Ee 's|^[^#]*--from=offline-builder.*|# &|' \
+  `# Enable cache_projects.sh` \
+  -Ee '/COPY --from=builder/a COPY --from=builder /build/resources /var/www/html/resources' \
+  -Ee '\|RUN ./index.sh|i # Cache projects in CRW\
+COPY ./build/dockerfiles/rhel.cache_projects.sh devfiles.tgz /tmp/\
+RUN /tmp/rhel.cache_projects.sh && rm -rf /tmp/rhel.cache_projects.sh /tmp/devfiles.tgz\
+'
 
 METADATA='ENV SUMMARY="Red Hat CodeReady Workspaces ''' + QUAY_PROJECT + ''' container" \\\r
     DESCRIPTION="Red Hat CodeReady Workspaces ''' + QUAY_PROJECT + ''' container" \\\r
@@ -153,6 +169,8 @@ LABEL summary="$SUMMARY" \\\r
       usage="" \r'
 
 echo -e "$METADATA" >> ${WORKSPACE}/target/Dockerfile
+
+cat ${WORKSPACE}/target/Dockerfile
 
 # push changes in github to dist-git
 cd ${WORKSPACE}/target
@@ -183,12 +201,14 @@ cd ${SOURCEDIR}
 # use Pulp to resolve deps
 # TODO use RHEL8 instead of EPEL7?
 sed -i ${SOURCEDOCKERFILE} \
-  -e "s@ *COPY \\(.\\+/content_sets\\)_epel7\\(.repo /etc/yum.repos.d\\)/@COPY \\1_rhel8\\2/@g" \
-	-e "s@# FROM builder AS offline-builder@FROM builder AS offline-builder@g"
+  -Ee 's|COPY (.*) cached_projects.tgz (.*)|COPY \1 \2|' \
+  -Ee 's|ARG BOOTSTRAP=.*|ARG BOOTSTRAP=true|' \
+  -Ee 's| *COPY root-local.tgz|# &|'
+
+cat ${SOURCEDOCKERFILE}
 
 CONTAINERNAME="devfileregistryoffline"
-docker build -t ${CONTAINERNAME} . --no-cache -f ${SOURCEDOCKERFILE} \
-  --target=offline-builder --build-arg BOOTSTRAP=true 
+docker build -t ${CONTAINERNAME} . --no-cache -f ${SOURCEDOCKERFILE}
 
 # update tarballs - step 2 - check old sources' tarballs
 cd ${WORKSPACE}/target
@@ -209,31 +229,39 @@ if [[ ${TAR_DIFF} ]]; then
   pushd /tmp/root-local >/dev/null && sudo tar czf root-local.tgz lib/ bin/ && popd >/dev/null && mv -f /tmp/root-local/root-local.tgz . && sudo rm -fr /tmp/root-local/
 fi
 
-# TODO CRW-590 use this diff for cached samples/images
+mkdir -p /tmp/devfiles/
+docker run --rm -v /tmp/devfiles/:/tmp/devfiles/ \
+  --entrypoint /bin/bash ${CONTAINERNAME} -c \
+  "cd /var/www/html && cp -r ./devfiles ./resources /tmp/devfiles/"
+
 # check diff
-#BEFORE_DIR=/tmp/pr-res-before
-#rm -fr ${BEFORE_DIR}; mkdir ${BEFORE_DIR} && tar xzf ${WORKSPACE}/target/v3.tgz -C ${BEFORE_DIR}
-#TAR_DIFF2=$(sudo diff --suppress-common-lines -u -r ${BEFORE_DIR} /tmp/pr-res -x "resources/*" -x "*.vsix" -x "*.theia") || true
-#if [[ ${TAR_DIFF2} ]]; then
-#  echo "DIFF START *****"
-#  echo "${TAR_DIFF2}"
-#  echo "***** END DIFF"
-#  pushd /tmp/pr-res >/dev/null && sudo tar czf v3.tgz ./* && popd >/dev/null && mv -f /tmp/pr-res/v3.tgz . && sudo rm -fr /tmp/pr-res/
-#fi
+BEFORE_DIR=/tmp/devfiles-before
+rm -fr ${BEFORE_DIR}; mkdir ${BEFORE_DIR} && tar xzf ${WORKSPACE}/target/devfiles.tgz -C ${BEFORE_DIR}
+TAR_DIFF2=$(sudo diff --suppress-common-lines -u -r ${BEFORE_DIR} /tmp/devfiles) || true
+if [[ ${TAR_DIFF2} ]]; then
+  echo "DIFF START *****"
+  echo "${TAR_DIFF2}"
+  echo "***** END DIFF"
+  pushd /tmp/devfiles/ >/dev/null && \
+    sudo tar czf devfiles.tgz ./* && \
+    popd >/dev/null && \
+    mv -f /tmp/devfiles/devfiles.tgz . && \
+    sudo rm -fr /tmp/devfiles/
+fi
 
 # update tarballs - step 4 - commit changes if diff different
 if [[ ${TAR_DIFF} ]] || [[ ${TAR_DIFF2} ]]; then
   hasChanged=1
   # TODO CRW-590 add tarball for devfile samples/images
-  rhpkg new-sources root-local.tgz 
-  git commit -s -m "[tgz] Update root-local.tgz and v3.tgz" sources
+  rhpkg new-sources root-local.tgz devfiles.tgz
+  git commit -s -m "[tgz] Update root-local.tgz and devfiles.tgz" sources
   git push origin ''' + GIT_BRANCH + '''
 else
   echo "No changes since previous tarball was created."
 fi
 
 # clean up diff dirs
-sudo rm -fr /tmp/root-local /tmp/root-local-before /tmp/pr-res /tmp/pr-res-before
+sudo rm -fr /tmp/root-local /tmp/root-local-before /tmp/devfiles /tmp/devfiles-before
 
 # NOTE: this image needs to build in Brew, then rebuild for Quay, so use QUAY_REBUILD_PATH instead of QUAY_REPO_PATHs variable
 if [[ ''' + FORCE_BUILD + ''' == "true" ]]; then hasChanged=1; fi

--- a/dependencies/che-devfile-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-devfile-registry/build/dockerfiles/Dockerfile
@@ -7,13 +7,14 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 FROM alpine:3.10 AS builder
-RUN apk add --no-cache py-pip jq bash wget git && pip install yq
+RUN apk add --no-cache py-pip jq bash wget git skopeo && pip install yq
 
 # Registry, organization, and tag to use for base images in dockerfiles. Devfiles
 # will be rewritten during build to use these values for base images.
 ARG PATCHED_IMAGES_REG="quay.io"
 ARG PATCHED_IMAGES_ORG="eclipse"
 ARG PATCHED_IMAGES_TAG="nightly"
+ARG USE_DIGESTS=false
 
 COPY ./build/scripts ./arbitrary-users-patch/base_images /build/
 COPY ./devfiles /build/devfiles
@@ -23,6 +24,7 @@ RUN TAG=${PATCHED_IMAGES_TAG} \
     REGISTRY=${PATCHED_IMAGES_REG} \
     ./update_devfile_patched_image_tags.sh
 RUN ./check_mandatory_fields.sh devfiles
+RUN if [[ ${USE_DIGESTS} == "true" ]]; then ./write_image_digests.sh devfiles; fi
 RUN ./index.sh > /build/devfiles/index.json
 RUN ./list_referenced_images.sh devfiles > /build/devfiles/external_images.txt
 RUN chmod -R g+rwX /build/devfiles

--- a/dependencies/che-devfile-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-devfile-registry/build/dockerfiles/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -40,9 +40,10 @@ INDEX_JSON="${DEVFILES_DIR}/index.json"
 #   \2 - Registry portion of image, e.g. (quay.io)/eclipse/che-theia:tag
 #   \3 - Organization portion of image, e.g. quay.io/(eclipse)/che-theia:tag
 #   \4 - Image name portion of image, e.g. quay.io/eclipse/(che-theia):tag
-#   \5 - Tag of image, e.g. quay.io/eclipse/che-theia:(tag)
-#   \6 - Optional quotation following image reference
-IMAGE_REGEX='([[:space:]]*"?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*):([._a-zA-Z0-9-]*)("?)'
+#   \5 - Optional image digest identifier (empty for tags), e.g. quay.io/eclipse/che-theia(@sha256):digest
+#   \6 - Tag of image or digest, e.g. quay.io/eclipse/che-theia:(tag)
+#   \7 - Optional quotation following image reference
+IMAGE_REGEX='([[:space:]]*"?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)("?)'
 
 # We can't use the `-d` option for readarray because
 # registry.centos.org/centos/httpd-24-centos7 ships with Bash 4.2
@@ -55,15 +56,15 @@ for devfile in "${devfiles[@]}"; do
   # Defaults don't work because registry and tags may be different.
   if [ -n "$REGISTRY" ]; then
     echo "    Updating image registry to $REGISTRY"
-    sed -i -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4:\5\6|" "$devfile"
+    sed -i -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" "$devfile"
   fi
   if [ -n "$ORGANIZATION" ]; then
     echo "    Updating image organization to $ORGANIZATION"
-    sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4:\5\6|" "$devfile"
+    sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" "$devfile"
   fi
   if [ -n "$TAG" ]; then
     echo "    Updating image tag to $TAG"
-    sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\6|" "$devfile"
+    sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" "$devfile"
   fi
 done
 

--- a/dependencies/che-devfile-registry/build/dockerfiles/rhel.cache_projects.sh
+++ b/dependencies/che-devfile-registry/build/dockerfiles/rhel.cache_projects.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Copyright (c) 2018-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+set -x
+
+if [[ ! -f /tmp/devfiles.tgz ]] || [[ ${BOOTSTRAP} == "true" ]]; then
+  ./cache_projects.sh devfiles resources
+else
+  tar -xvf /tmp/devfiles.tgz -C "${WORKDIR}/"
+fi

--- a/dependencies/che-devfile-registry/build/dockerfiles/rhel.entrypoint.sh
+++ b/dependencies/che-devfile-registry/build/dockerfiles/rhel.entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dependencies/che-devfile-registry/build/dockerfiles/rhel.install.sh
+++ b/dependencies/che-devfile-registry/build/dockerfiles/rhel.install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-microdnf install -y findutils bash wget yum gzip git tar jq python3-six python3-pip && microdnf -y clean all && \
+microdnf install -y findutils bash wget yum gzip git tar jq python3-six python3-pip skopeo && microdnf -y clean all && \
 # install yq (depends on jq and pyyaml - if jq and pyyaml not already installed, this will try to compile it)
 if [[ -f /tmp/root-local.tgz ]] || [[ ${BOOTSTRAP} == "true" ]]; then \
     mkdir -p /root/.local; tar xf /tmp/root-local.tgz -C /root/.local/; rm -fr /tmp/root-local.tgz;  \

--- a/dependencies/che-devfile-registry/build/scripts/cache_images.sh
+++ b/dependencies/che-devfile-registry/build/scripts/cache_images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dependencies/che-devfile-registry/build/scripts/cache_projects.sh
+++ b/dependencies/che-devfile-registry/build/scripts/cache_projects.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dependencies/che-devfile-registry/build/scripts/index.sh
+++ b/dependencies/che-devfile-registry/build/scripts/index.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dependencies/che-devfile-registry/build/scripts/write_image_digests.sh
+++ b/dependencies/che-devfile-registry/build/scripts/write_image_digests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+
+readarray -d '' devfiles < <(find "$1" -name 'devfile.yaml' -print0)
+for image in $(yq -r '.components[]?.image' "${devfiles[@]}" | grep -v "null" | sort | uniq); do
+  echo "Rewriting image $image"
+  digest=$(skopeo inspect "docker://${image}" | jq -r '.Digest')
+  echo "  to use digest $digest"
+  digest_image="${image%:*}@${digest}"
+
+  # Rewrite images to use sha-256 digests
+  sed -i -E 's|"?'"${image}"'"?|"'"${digest_image}"'" # tag: '"${image}"'|g' "${devfiles[@]}"
+done


### PR DESCRIPTION
Update the Jenkins script for [syncing the devfile registry to pkgs.devel](https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/CRW_CI/view/Releng/job/crw-devfileregistry_sync-github-to-pkgs.devel-pipeline/). 

### Changes

- Use `rhel.Dockerfile` copied directly from upstream repo and apply *all* required patches in CI (hence the monstrous `sed` sequence).
- Add building of new source `devfiles.tgz`, which ends up in the lookaside.

I've tested the changes as best I can locally.

Sample patched dockerfile (output of running the big `sed` on `rhel.Dockerfile`):

```dockerfile
#
# Copyright (c) 2018-2020 Red Hat, Inc.
# This program and the accompanying materials are made
# available under the terms of the Eclipse Public License 2.0
# which is available at https://www.eclipse.org/legal/epl-2.0/
#
# SPDX-License-Identifier: EPL-2.0
#
# Contributors:
#   Red Hat, Inc. - initial API and implementation
#

# Builder: check meta.yamls and create index.json
# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
FROM ubi8-minimal:8.1-398 as builder
USER 0

################# 
# PHASE ONE: create ubi8-minimal image with yq
################# 

ARG BOOTSTRAP=false
ENV BOOTSTRAP=${BOOTSTRAP}
ARG USE_DIGESTS=true
ENV USE_DIGESTS=${USE_DIGESTS}

# to get all the python deps pre-fetched so we can build in Brew:
# 1. extract files in the container to your local filesystem
#    find v3 -type f -exec dos2unix {} \;
#    CONTAINERNAME="devfileregistrybuilder" && docker build -t ${CONTAINERNAME} . --target=builder --no-cache --squash --build-arg BOOTSTRAP=true
#    mkdir -p /tmp/root-local/ && docker run -it -v /tmp/root-local/:/tmp/root-local/ ${CONTAINERNAME} /bin/bash -c "cd /root/.local/ && cp -r bin/ lib/ /tmp/root-local/"
#    pushd /tmp/root-local >/dev/null && sudo tar czf root-local.tgz lib/ bin/ && popd >/dev/null && mv -f /tmp/root-local/root-local.tgz . && sudo rm -fr /tmp/root-local/

# 2. then add it to dist-git so it's part of this repo
#    rhpkg new-sources root-local.tgz 

# built in Brew, use tarball in lookaside cache; built locally, comment this out
COPY root-local.tgz /tmp/root-local.tgz

# NOTE: uncomment for local build. Must also set full registry path in FROM to registry.redhat.io or registry.access.redhat.com
# enable rhel 7 or 8 content sets (from Brew) to resolve jq as rpm
# COPY ./build/dockerfiles/content_sets_centos8_appstream.repo /etc/yum.repos.d/

COPY ./build/dockerfiles/rhel.install.sh /tmp
RUN /tmp/rhel.install.sh && rm -f /tmp/rhel.install.sh

# Registry, organization, and tag to use for base images in dockerfiles. Devfiles
# will be rewritten during build to use these values for base images.
# ARG PATCHED_IMAGES_REG="quay.io"
# ARG PATCHED_IMAGES_ORG="eclipse"
# ARG PATCHED_IMAGES_TAG="nightly"

COPY ./build/scripts ./arbitrary-users-patch/base_images /build/
COPY ./devfiles /build/devfiles
WORKDIR /build/
# RUN TAG=${PATCHED_IMAGES_TAG} \
#     ORGANIZATION=${PATCHED_IMAGES_ORG} \
#     REGISTRY=${PATCHED_IMAGES_REG} \
#     ./update_devfile_patched_image_tags.sh
RUN ./check_mandatory_fields.sh devfiles
RUN if [[ ${USE_DIGESTS} == "true" ]]; then ./write_image_digests.sh devfiles; fi
# Cache projects in CRW
COPY ./build/dockerfiles/rhel.cache_projects.sh devfiles.tgz /tmp/
RUN /tmp/rhel.cache_projects.sh /build/ && rm -rf /tmp/rhel.cache_projects.sh /tmp/devfiles.tgz

RUN ./index.sh > /build/devfiles/index.json
RUN ./list_referenced_images.sh devfiles > /build/devfiles/external_images.txt
RUN chmod -R g+rwX /build/devfiles

################# 
# PHASE TWO: configure registry image
################# 

# Build registry, copying meta.yamls and index.json from builder
# UPSTREAM: use RHEL7/RHSCL/httpd image so we're not required to authenticate with registry.redhat.io
# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/rhscl/httpd-24-rhel7
# FROM rhscl/httpd-24-rhel7:2.4-108.1575996463 AS registry

# DOWNSTREAM: use RHEL8/httpd
# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/rhel8/httpd-24
FROM rhel8/httpd-24:1-76 AS registry
USER 0

# BEGIN these steps might not be required
RUN sed -i /etc/httpd/conf/httpd.conf \
    -e "s,Listen 80,Listen 8080," \
    -e "s,logs/error_log,/dev/stderr," \
    -e "s,logs/access_log,/dev/stdout," \
    -e "s,AllowOverride None,AllowOverride All," && \
    chmod a+rwX /etc/httpd/conf /run/httpd /etc/httpd/logs/
STOPSIGNAL SIGWINCH
# END these steps might not be required

WORKDIR /var/www/html

RUN mkdir -m 777 /var/www/html/devfiles
COPY .htaccess README.md /var/www/html/
COPY --from=builder /build/devfiles /var/www/html/devfiles
COPY --from=builder /build/resources /var/www/html/resources
COPY ./images /var/www/html/images
COPY ./build/dockerfiles/rhel.entrypoint.sh ./build/dockerfiles/entrypoint.sh /usr/local/bin/
RUN chmod g+rwX /usr/local/bin/entrypoint.sh /usr/local/bin/rhel.entrypoint.sh
ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
CMD ["/usr/local/bin/rhel.entrypoint.sh"]

# Offline devfile registry build
# FROM builder AS offline-builder
# RUN ./cache_projects.sh devfiles resources && \
#     ./cache_images.sh devfiles resources && \
#     chmod -R g+rwX /build

# FROM registry AS offline-registry
# COPY --from=offline-builder /build/devfiles /var/www/html/devfiles
# COPY --from=offline-builder /build/resources /var/www/html/resources

# append Brew metadata here
```