### PR TITLE
Use relative image paths in devfile meta.yamls

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/meta.yaml
@@ -2,5 +2,5 @@
 displayName: Java EAP Maven
 description: RHEL 8 Java stack with EAP 7.2, OpenJDK 1.8 and Maven 3.5
 tags: ["Java", "OpenJDK", "Maven", "EAP"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-jboss.svg?sanitize=true
+icon: /images/type-jboss.svg
 globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/01_java-eap-thorntail/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/01_java-eap-thorntail/meta.yaml
@@ -2,5 +2,5 @@
 displayName: Thorntail REST HTTP
 description: Quickstart to expose a REST Greeting endpoint using Thorntail
 tags: ["Java", "OpenJDK", "Maven", "EAP"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-thorntail.svg?sanitize=true
+icon: /images/type-thorntail.svg
 globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/meta.yaml
@@ -2,5 +2,5 @@
 displayName: Red Hat Fuse
 description: Red Hat Fuse
 tags: ["OpenJDK", "Maven", "EAP"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-fuse.svg?sanitize=true
+icon: /images/type-fuse.svg
 globalMemoryLimit: 2816Mi

--- a/dependencies/che-devfile-registry/devfiles/02_java-maven/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-maven/meta.yaml
@@ -2,5 +2,5 @@
 displayName: Java Maven
 description: Java Stack with OpenJDK 8 and Maven 3.5.4
 tags: ["Java", "OpenJDK", "Maven"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-java.svg?sanitize=true
+icon: /images/type-java.svg
 globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/03_camelk/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_camelk/meta.yaml
@@ -2,5 +2,5 @@
 displayName: Apache Camel K
 description: Tooling to develop Integration projects with Apache Camel K
 tags: ["Apache Camel K", "Red Hat Fuse", "Integration"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-fuse.svg?sanitize=true
+icon: /images/type-fuse.svg
 globalMemoryLimit: 2850Mi

--- a/dependencies/che-devfile-registry/devfiles/03_java11-gradle/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_java11-gradle/meta.yaml
@@ -2,5 +2,5 @@
 displayName: Java Gradle
 description: Java Stack with OpenJDK 11 and Gradle 6.1
 tags: ["Java", "GraalVM", "Gradle", "ubi8"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-gradle.svg?sanitize=true
+icon: /images/type-gradle.svg
 globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/03_java11-quarkus/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_java11-quarkus/meta.yaml
@@ -2,5 +2,5 @@
 displayName: Quarkus Tools
 description: Quarkus Tools with GraalVM and Maven 3.6.0
 tags: ["Java", "Quarkus", "GraalVM", "Maven", "ubi8"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-quarkus.svg?sanitize=true
+icon: /images/type-quarkus.svg
 globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/meta.yaml
@@ -2,5 +2,5 @@
 displayName: Java Spring Boot
 description: Java stack with OpenJDK 8 and Spring Boot Petclinic demo application
 tags: ["Java", "OpenJDK", "Maven", "Spring Boot"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-snowdrop.svg?sanitize=true
+icon: /images/type-snowdrop.svg
 globalMemoryLimit: 3072Mi

--- a/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/meta.yaml
@@ -2,5 +2,5 @@
 displayName: Java Vert.x
 description: Java stack with OpenJDK 8 and Vert.x demo application
 tags: ["Java", "OpenJDK", "Maven", "Vertx"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-vertx.svg?sanitize=true
+icon: /images/type-vertx.svg
 globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/03_web-nodejs-simple/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_web-nodejs-simple/meta.yaml
@@ -2,5 +2,5 @@
 displayName: NodeJS Express Web Application
 description: Stack with NodeJS 10
 tags: ["NodeJS", "Express", "ubi8"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-node.svg?sanitize=true
+icon: /images/type-node.svg
 globalMemoryLimit: 1686Mi

--- a/dependencies/che-devfile-registry/devfiles/04_nodejs-mongo/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/04_nodejs-mongo/meta.yaml
@@ -2,5 +2,5 @@
 displayName: NodeJS MongoDB Web Application
 description: Stack with NodeJS 10 and MongoDB 3.4
 tags: ["NodeJS", "Express", "MongoDB", "RealWorld", "ubi8", "Centos"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-node.svg?sanitize=true
+icon: /images/type-node.svg
 globalMemoryLimit: 1686Mi

--- a/dependencies/che-devfile-registry/devfiles/05_cpp/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_cpp/meta.yaml
@@ -2,5 +2,5 @@
 displayName: C/C++
 description: C and C++ Developer Tools stack
 tags: ["c", "c++", "clang", "g++", "make", "cmake"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-cpp.svg?sanitize=true
+icon: /images/type-cpp.svg
 globalMemoryLimit: 1686Mi

--- a/dependencies/che-devfile-registry/devfiles/05_dotnet/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_dotnet/meta.yaml
@@ -2,5 +2,5 @@
 displayName: ".NET"
 description: .NET 3.1 stack with .NET Core SDK, Runtime, C# Language Support and Debugger
 tags: [".NET", "C#"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-dotnet.svg?sanitize=true
+icon: /images/type-dotnet.svg
 globalMemoryLimit: 2198Mi

--- a/dependencies/che-devfile-registry/devfiles/05_go/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_go/meta.yaml
@@ -2,5 +2,5 @@
 displayName: Go
 description: Stack with Go 1.11.5
 tags: ["Go"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-go.svg?sanitize=true
+icon: /images/type-go.svg
 globalMemoryLimit: 1686Mi

--- a/dependencies/che-devfile-registry/devfiles/05_php-cake/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_php-cake/meta.yaml
@@ -2,5 +2,5 @@
 displayName: "CakePHP Example"
 description: PHP Stack with PHP 7.1 and a quickstart CakePHP application for OpenShift v3
 tags: ["PHP", "Apache", "RHEL"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-php.svg?sanitize=true
+icon: /images/type-php.svg
 globalMemoryLimit: 2430Mi

--- a/dependencies/che-devfile-registry/devfiles/05_php-web-simple/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_php-web-simple/meta.yaml
@@ -2,5 +2,5 @@
 displayName: "PHP Simple"
 description: PHP Stack with PHP 7.1 and simple web application
 tags: ["PHP", "Apache", "RHEL"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-php.svg?sanitize=true
+icon: /images/type-php.svg
 globalMemoryLimit: 2430Mi

--- a/dependencies/che-devfile-registry/devfiles/05_python/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_python/meta.yaml
@@ -2,5 +2,5 @@
 displayName: Python
 description: Python Stack with Python 3.6
 tags: ["Python", "pip"]
-icon: https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/che-devfile-registry/images/type-python.svg?sanitize=true
+icon: /images/type-python.svg
 globalMemoryLimit: 1686Mi


### PR DESCRIPTION
With upstream version 7.8.0, we should be able to use the icons stored in the registry itself, to avoid having to cache icons during build.