### PR TITLE
Fix entrypoint for devfile registry, since crw service has different name

### DIFF
--- a/dependencies/che-devfile-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-devfile-registry/build/dockerfiles/entrypoint.sh
@@ -80,7 +80,9 @@ else
     # Experimental workaround -- detect service IP for che-devfile-registry
     # Depends on service used being named 'che-devfile-registry' and only works
     # within the cluster (i.e. browser-side retrieval won't work)
-    URL="http://${CHE_DEVFILE_REGISTRY_SERVICE_HOST}:${CHE_DEVFILE_REGISTRY_SERVICE_PORT}"
+    SERVICE_HOST=$(env | grep DEVFILE_REGISTRY_SERVICE_HOST= | cut -d '=' -f 2)
+    SERVICE_PORT=$(env | grep DEVFILE_REGISTRY_SERVICE_PORT= | cut -d '=' -f 2)
+    URL="http://${SERVICE_HOST}:${SERVICE_PORT}"
     sed -i "s|{{ DEVFILE_REGISTRY_URL }}|${URL}|" "${devfiles[@]}" "${metas[@]}" "$INDEX_JSON"
   fi
 fi


### PR DESCRIPTION
The CRW registries are provisioned with services devfile-registry and plugin-registry; this breaks the fallback airgap option for attempting to determine a local URL

Note that this fallback option is pretty untested and should not be relied upon in general; it could break in many circumstances, e.g. across namespace boundaries, depending on cluster configuration.

The change is only made for the devfile registry at the moment, since it's less likely to cause issues.