### PR TITLE
Add nodejs configmap sample

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/03_nodejs-configmap/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_nodejs-configmap/devfile.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: 1.0.0
+metadata:
+  generateName: nodejs-configmap-
+projects:
+  - name: nodejs-configmap
+    source:
+      location: "https://github.com/nodeshift-starters/nodejs-configmap"
+      type: git
+      branch: master
+components:
+  - id: che-incubator/typescript/latest
+    type: chePlugin
+    memoryLimit: 512Mi
+  - mountSources: true
+    memoryLimit: 1Gi
+    type: dockerimage
+    alias: nodejs
+    image: registry.redhat.io/codeready-workspaces/stacks-node-rhel8:2.0-5.1580285284
+  - id: redhat/vscode-openshift-connector/latest
+    type: chePlugin
+    alias: openshift-connector
+    memoryLimit: 512Mi
+commands:
+  - name: 1. Install dependencies
+    actions:
+      - workdir: "${CHE_PROJECTS_ROOT}/nodejs-configmap"
+        type: exec
+        command: npm install
+        component: nodejs
+  - name: 2. Deploy application
+    actions:
+      - workdir: "${CHE_PROJECTS_ROOT}/nodejs-configmap"
+        type: exec
+        command: npm run openshift
+        component: nodejs

--- a/dependencies/che-devfile-registry/devfiles/03_nodejs-configmap/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_nodejs-configmap/meta.yaml
@@ -1,0 +1,6 @@
+---
+displayName: NodeJS ConfigMap
+description: Stack with NodeJS 10
+tags: ["NodeJS"]
+icon: /images/type-node.svg
+globalMemoryLimit: 2024Mi


### PR DESCRIPTION
This PR introduces a new nodejs configmap devfile based off of https://github.com/nodeshift-starters/nodejs-configmap.

(I assume registry.redhat.io/codeready-workspaces/stacks-node-rhel8:2.1 will be released with codeready workspaces but I was testing against registry.redhat.io/codeready-workspaces/stacks-node-rhel8:2.0-5.1580285284)