### PR TITLE
CRW-673 update replaceregexp to use 'che-service.factory.ts'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,7 +150,7 @@ timeout(180) {
 
 		// insert a longer version string which includes both CRW and Che, plus build and SHA info
 		// not sure if this does anything. See also assembly/codeready-workspaces-assembly-dashboard-war/pom.xml line 109
-		sh "sed -i -e \"s#\\(.\\+productVersion = \\).\\+#\\1'${CRW_SHAs}';#g\" che/dashboard/src/components/branding/che-branding.ts"
+		sh "sed -i -e \"s#\\(.\\+productVersion = \\).\\+#\\1'${CRW_SHAs}';#g\" che/dashboard/src/components/api/che-service.factory.ts"
 
 		// apply CRW CSS
 		sh '''#!/bin/bash -xe

--- a/assembly/codeready-workspaces-assembly-dashboard-war/pom.xml
+++ b/assembly/codeready-workspaces-assembly-dashboard-war/pom.xml
@@ -106,7 +106,7 @@
                                     <isset property="JOB_NAME" />
                                 </condition>
                                 <!--       this.$rootScope.productVersion = (info && info.implementationVersion) ? info.implementationVersion : ''; -->
-                                <replaceregexp byline="true" file="${project.build.directory}/source-war/components/branding/che-branding.ts" match="(.+productVersion = ).+" replace="\1'${productVersion}';" />
+                                <replaceregexp byline="true" file="${project.build.directory}/source-war/components/api/che-service.factory.ts" match="(.+productVersion = ).+" replace="\1'${productVersion}';" />
                             </tasks>
                         </configuration>
                     </execution>


### PR DESCRIPTION
### What does this PR do?
Update replaceregexp to use 'che-service.factory.ts' instead of 'che-branding.ts'.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-673

The build result after:
![Screenshot from 2020-03-04 01-44-24](https://user-images.githubusercontent.com/6310786/75830826-81ba6c80-5dba-11ea-9b1f-c0fb0ebf936a.png)

Signed-off-by: Oleksii Orel <oorel@redhat.com>