### PR TITLE
CRW-701 clarify that 'Start development...

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/03_java11-quarkus/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_java11-quarkus/devfile.yaml
@@ -48,7 +48,7 @@ commands:
         command: "mvn package"
         workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started
   -
-    name: Start development server
+    name: Start development server (debug mode)
     actions:
       -
         type: exec


### PR DESCRIPTION
CRW-701 clarify that 'Start development server' enables debugging

Change-Id: I5e194807e0ceb04b84e7f66cef83e5101400fc1f
Signed-off-by: nickboldt <nboldt@redhat.com>