### PR TITLE
Change endpoint's name

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/05_dotnet/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_dotnet/devfile.yaml
@@ -26,7 +26,7 @@ components:
     image: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8:2.1
     memoryLimit: 512Mi
     endpoints:
-      - name: '5000/tcp'
+      - name: 'hello-endpoint'
         port: 5000
     mountSources: true
     volumes:


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Changes endpoint's name from `5000/tcp` to `hello-endpoint`. 
Looks like the problem is because the name contains `/` symbol. 
![screenshot-codeready-iokhrime-crw2 apps ocp44 codereadyqe com-2020 03 (1)](https://user-images.githubusercontent.com/1271546/76777376-c8439a00-67b0-11ea-8c49-6c4d115baeff.png)
![screenshot-codeready-iokhrime-crw2 apps ocp44 codereadyqe com-2020 03](https://user-images.githubusercontent.com/1271546/76777383-ca0d5d80-67b0-11ea-8259-4a0ef1502da7.png)


The real problem should be fixed in upstream

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-717

cc @nickboldt 
