### PR TITLE
Update the command to debug kitchensink-eap application

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/devfile.yaml
@@ -42,7 +42,11 @@ commands:
       -
         type: exec
         component: maven
-        command: "mvn clean install && cp target/*.war /opt/eap/standalone/deployments/ROOT.war && export JAVA_OPTS_APPEND=-Dsun.util.logging.disableCallerCheck=true && /opt/eap/bin/openshift-launch.sh -b 0.0.0.0 --debug 8000"
+        command: >-
+          mvn clean install && 
+          cp target/*.war /opt/eap/standalone/deployments/ROOT.war && 
+          export JAVA_OPTS_APPEND="-Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n -Dsun.util.logging.disableCallerCheck=true" && 
+          /opt/eap/bin/openshift-launch.sh
         workdir: ${CHE_PROJECTS_ROOT}/kitchensink-example
   -
     name: copy war


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Updates  **build and run in debug** command in **java-eap-maven** devfile to make debugger possible to attache to the remote process and debug eap application.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-724

cc @nickboldt 
