### PR TITLE
Patch version of the Dashboard

### DIFF
--- a/assembly/codeready-workspaces-assembly-dashboard-war/pom.xml
+++ b/assembly/codeready-workspaces-assembly-dashboard-war/pom.xml
@@ -67,7 +67,7 @@
                 <version>1.8</version>
                 <executions>
                     <execution>
-                        <id>update-docs-version-product-json</id>
+                        <id>update-product-json</id>
                         <phase>validate</phase>
                         <goals>
                             <goal>run</goal>
@@ -76,6 +76,7 @@
                             <tasks>
                                 <copy file="${product.json.file}.template" overwrite="true" tofile="${product.json.file}" />
                                 <replace file="${product.json.file}" token="@@crw.docs.baseurl@@" value="${crw.docs.baseurl}" />
+                                <replace file="${product.json.file}" token="@@crw.version@@" value="${crw.dashboard.version} :: ${JOB_NAME} # ${BUILD_NUMBER} @ ${GIT_COMMIT} / ${GIT_BRANCH}" />
                             </tasks>
                         </configuration>
                     </execution>
@@ -90,23 +91,6 @@
                                 <copy overwrite="true" todir="${project.build.directory}/source-war">
                                     <fileset dir="${project.basedir}/src/main/webapp" />
                                 </copy>
-                            </tasks>
-                        </configuration>
-                    </execution>
-                    <!-- apply dashboard version string -->
-                    <execution>
-                        <id>dashboard-version-string-update</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <tasks>
-                                <condition else="${crw.dashboard.version}" property="productVersion" value="${crw.dashboard.version} :: ${JOB_NAME} # ${BUILD_NUMBER} @ ${GIT_COMMIT} / ${GIT_BRANCH}">
-                                    <isset property="JOB_NAME" />
-                                </condition>
-                                <!--       this.$rootScope.productVersion = (info && info.implementationVersion) ? info.implementationVersion : ''; -->
-                                <replaceregexp byline="true" file="${project.build.directory}/source-war/components/api/che-service.factory.ts" match="(.+productVersion = ).+" replace="\1'${productVersion}';" />
                             </tasks>
                         </configuration>
                     </execution>

--- a/assembly/codeready-workspaces-assembly-dashboard-war/src/main/webapp/assets/branding/product.json.template
+++ b/assembly/codeready-workspaces-assembly-dashboard-war/src/main/webapp/assets/branding/product.json.template
@@ -1,6 +1,7 @@
 {
   "title": "CodeReady Workspaces ",
   "name": "CodeReady Workspaces",
+  "productVersion": "@@crw.version@@",
   "logoFile": "che-logo.svg",
   "logoTextFile": "che-logo-text.svg",
   "favicon": "favicon.ico",


### PR DESCRIPTION
### What does this PR do?
Patches version of the Dashboard.
Upstream related changes were merged in https://github.com/eclipse/che/pull/16406

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-673

#### Is it tested? How?
Not fully. I mean I've done:
```bash
export JOB_NAME="sleshche-local"
export BUILD_NUMBER=1
export GIT_COMMIT=123456
export GIT_BRANCH=patchedVersion
mvn clean install
```
and checked that the build tomcat.zip contains patched version but I have not built and deploy CRW to check if Dashboard displays it
![Screenshot_20200320_090628](https://user-images.githubusercontent.com/5887312/77142868-1ba43980-6a8a-11ea-93c8-3354f9549f77.png)
