### PR TITLE
Replace hello-java sample with vertx-health-checks-example-redhat

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/02_java-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-maven/devfile.yaml
@@ -1,13 +1,13 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  generateName: java-maven-
+  generateName: vertx-health-checks-
 projects:
   -
-    name: console-java-simple
+    name: vertx-health-checks-example-redhat
     source:
       type: git
-      location: "https://github.com/che-samples/console-java-simple"
+      location: "https://github.com/openshift-vertx-examples/vertx-health-checks-example-redhat"
 components:
   -
     type: chePlugin
@@ -26,27 +26,68 @@ components:
     volumes:
       - name: m2
         containerPath: /home/jboss/.m2
+    endpoints:
+      - name: 'health-checks-endpoint'
+        port: 8080 
 commands:
   -
-    name: maven build
+    name: Build
     actions:
       -
         type: exec
         component: maven
         command: "mvn clean install"
-        workdir: ${CHE_PROJECTS_ROOT}/console-java-simple
+        workdir: ${CHE_PROJECTS_ROOT}/vertx-health-checks-example-redhat
   -
-    name: maven build and run
+    name: Build and run
     actions:
       -
         type: exec
         component: maven
-        command: "mvn clean install && java -jar ./target/*.jar"
-        workdir: ${CHE_PROJECTS_ROOT}/console-java-simple
+        command: "mvn clean install && mvn -Dvertx.disableDnsResolver=true vertx:run"
+        workdir: ${CHE_PROJECTS_ROOT}/vertx-health-checks-example-redhat
   -
-    name: dependency analysis
+    name: Run in debug mode
+    actions:
+      - workdir: '${CHE_PROJECTS_ROOT}/vertx-health-checks-example-redhat'
+        type: exec
+        command: "mvn -DskipTests vertx:debug"
+        component: maven
+  - 
+    name: Run tests
+    actions:
+      - workdir: '${CHE_PROJECTS_ROOT}/vertx-health-checks-example-redhat'
+        type: exec
+        command: "mvn verify"
+        component: maven
+  - 
+    name: Deploy to OpenShift
+    actions:
+      - workdir: '${CHE_PROJECTS_ROOT}/vertx-health-checks-example-redhat'
+        type: exec
+        command: "mvn fabric8:deploy -Popenshift -DskipTests -Dvertx.disableDnsResolver=true"
+        component: maven
+  -  
+    name: Dependency analysis
     actions:
       -
         type: exec
         component: maven
-        command: "${HOME}/stack-analysis.sh -f ${CHE_PROJECTS_ROOT}/console-java-simple/pom.xml -p ${CHE_PROJECTS_ROOT}/console-java-simple"
+        command: "${HOME}/stack-analysis.sh -f ${CHE_PROJECTS_ROOT}/vertx-health-checks-example-redhat/pom.xml -p ${CHE_PROJECTS_ROOT}/vertx-health-checks-example-redhat"
+  -
+    name: Attach remote debugger
+    actions:
+    - type: vscode-launch
+      referenceContent: |
+        {
+        "version": "0.2.0",
+        "configurations": [
+        {
+            "type": "java",
+            "request": "attach",
+            "name": "Debug (Attach)",
+            "hostName": "localhost",
+            "port": 5005
+        }
+        ]
+        }

--- a/dependencies/che-devfile-registry/devfiles/02_java-maven/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-maven/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Java Maven
-description: Java Stack with OpenJDK 8 and Maven 3.5.4
-tags: ["Java", "OpenJDK", "Maven"]
+description: Java stack with OpenJDK 8, Maven 3.5.4 and Vert.x demo application
+tags: ["Java", "OpenJDK", "Maven", "Vert.x"]
 icon: /images/type-java.svg
 globalMemoryLimit: 2674Mi


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
-  Updates existing **java-maven** devfile by replacing console-java-simple example with [vertx-health-checks-example-redhat](https://github.com/openshift-vertx-examples/vertx-health-checks-example-redhat).
![screenshot-codeready-iokhrime-crw11 apps ocp44 codereadyqe com-2020 03 24-12_54_11](https://user-images.githubusercontent.com/1271546/77418076-0e12ea80-6dcf-11ea-857b-4294a1c54050.png)
-  Updates list of commands
![screenshot-codeready-iokhrime-crw11 apps ocp44 codereadyqe com-2020 03 24-12_57_52](https://user-images.githubusercontent.com/1271546/77418111-1e2aca00-6dcf-11ea-9416-f27737bf7d28.png)
### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-412

cc @nickboldt 

