### PR TITLE
[Che 7.13] Updated Go stack's go.lintFlags to array

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/05_go/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_go/devfile.yaml
@@ -17,7 +17,7 @@ components:
   memoryLimit: 512Mi
   preferences:
     go.lintTool: 'golangci-lint'
-    go.lintFlags: '--fast'
+    go.lintFlags: ['--fast']
 -
   type: dockerimage
   image: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8:2.1


### PR DESCRIPTION
### What does this PR do?
Updates go stack's go.lintFlags parameter to use an array instead of string
Please see docs: https://github.com/microsoft/vscode-go#linter

### What issues does this PR fix or reference?
While trying out Go stack on eclipse che hosted by Red Hat, user will recieve the folowing message:
<img width="1440" alt="Screenshot 2020-03-26 at 12 13 16 PM" src="https://user-images.githubusercontent.com/8397274/77617883-34fe2780-6f5b-11ea-93b9-8e206f9aac3f.png">


<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->         
