### PR TITLE
Set more memory for openshift connector plugin

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/04_nodejs-configmap/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/04_nodejs-configmap/devfile.yaml
@@ -20,7 +20,7 @@ components:
   - id: redhat/vscode-openshift-connector/latest
     type: chePlugin
     alias: openshift-connector
-    memoryLimit: 1Gi
+    memoryLimit: 1280Mi
 commands:
   - name: 1. Install dependencies
     actions:

--- a/dependencies/che-devfile-registry/devfiles/04_nodejs-configmap/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/04_nodejs-configmap/meta.yaml
@@ -3,4 +3,4 @@ displayName: NodeJS ConfigMap
 description: Stack with NodeJS 10
 tags: ["NodeJS"]
 icon: /images/type-node.svg
-globalMemoryLimit: 3072Mi
+globalMemoryLimit: 2792Mi

--- a/dependencies/che-plugin-registry/v3/plugins/redhat/vscode-openshift-connector/0.1.2/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/vscode-openshift-connector/0.1.2/meta.yaml
@@ -17,6 +17,6 @@ spec:
   containers:
     - image: "registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1"
       name: "vscode-openshift-connector"
-      memoryLimit: "512Mi"
+      memoryLimit: "1280Mi"
   extensions:
     - https://github.com/redhat-developer/vscode-openshift-tools/releases/download/v0.1.2/openshift-connector-0.1.2-420.vsix

--- a/dependencies/che-plugin-registry/v3/plugins/redhat/vscode-openshift-connector/0.1.4/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/vscode-openshift-connector/0.1.4/meta.yaml
@@ -14,6 +14,6 @@ spec:
   containers:
     - image: "registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1"
       name: "vscode-openshift-connector"
-      memoryLimit: "512Mi"
+      memoryLimit: "1280Mi"
   extensions:
     - https://download.jboss.org/jbosstools/vscode/stable/vscode-openshift-tools/openshift-connector-0.1.4-523.vsix


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Set **1280Mi** as a memory limit for openshift connector plug-in. 

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-746
