### PR TITLE
CRW-776 docker container for golang sets...

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/05_go/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_go/devfile.yaml
@@ -25,7 +25,7 @@ components:
   env:
     - name: GOPATH
       # replicate the GOPATH from the plugin
-      value: /go:$(CHE_PROJECTS_ROOT)
+      value: /projects/.che/gopath:$(CHE_PROJECTS_ROOT)
     - name: GOCACHE
       # replicate the GOCACHE from the plugin, even though the cache is not shared
       # between the two


### PR DESCRIPTION
CRW-776 docker container for golang sets GOPATH=/projects/.che/gopath so presumably we should do the same here since /go doesn't exist and isn't user-writeable

Change-Id: Ia0a681c77f666f47de4115da56f6292133ed410c
Signed-off-by: nickboldt <nboldt@redhat.com>