### PR TITLE
[CRW 2.2] Update Gradle devfile to use new sample

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/03_java11-gradle/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_java11-gradle/devfile.yaml
@@ -4,11 +4,11 @@ metadata:
   generateName: java-gradle-
 projects:
   -
-    name: console-java-simple
+    name: validating-form-input
     source:
       type: git
-      location: "https://github.com/che-samples/console-java-simple.git"
-      branch: java1.11
+      location: "https://github.com/crw-samples/gs-validating-form-input.git"
+      sparseCheckoutDir: complete
 components:
   -
     type: chePlugin
@@ -33,32 +33,39 @@ components:
     volumes:
       - name: gradle
         containerPath: /home/jboss/.gradle
+    endpoints:
+      - name: input-form-endpoint
+        port: 8080
     mountSources: true
 commands:
-  -
-    name: Build application
+  - 
+    name: Build
     actions:
-      -
+      - workdir: '${CHE_PROJECTS_ROOT}/validating-form-input/complete'
         type: exec
+        command: gradle build
         component: gradle
-        command: "gradle build"
-        workdir: ${CHE_PROJECTS_ROOT}/console-java-simple
-  -
-    name: Run application
-    actions:
-      -
-        type: exec
-        component: gradle
-        command: "gradle run"
-        workdir: ${CHE_PROJECTS_ROOT}/console-java-simple
   -
     name: Debug application
     actions:
-      -
+      - workdir: '${CHE_PROJECTS_ROOT}/validating-form-input/complete'
         type: exec
+        command: gradle bootRun --debug-jvm
         component: gradle
-        command: "gradle run --debug-jvm"
-        workdir: ${CHE_PROJECTS_ROOT}/console-java-simple
+  -
+    name: Run application
+    actions:
+      - workdir: '${CHE_PROJECTS_ROOT}/validating-form-input/complete'
+        type: exec
+        command: gradle bootRun
+        component: gradle
+  -
+    name: Run tests
+    actions:
+      - workdir: '${CHE_PROJECTS_ROOT}/validating-form-input/complete'
+        type: exec
+        command: gradle test
+        component: gradle
   - name: Debug remote java application
     actions:
       - referenceContent: |


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
-  Updates existing java-gradle devfile by replacing console-java-simple example with [gs-validating-form-input](https://github.com/crw-samples/gs-validating-form-input)
![screenshot-che openshift io-2020 03 25-14_15_00](https://user-images.githubusercontent.com/1271546/77535292-10467900-6ea3-11ea-9deb-6b3de5fecaa6.png)

-  Updates list of commands:
![screenshot-che openshift io-2020 03 25-14_13_39](https://user-images.githubusercontent.com/1271546/77535222-ebea9c80-6ea2-11ea-869a-37cac463c2e8.png)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-412
