### PR TITLE
Fail registry builds if a digest is not found

### DIFF
--- a/dependencies/che-devfile-registry/build/scripts/write_image_digests_alternate_urls.sh
+++ b/dependencies/che-devfile-registry/build/scripts/write_image_digests_alternate_urls.sh
@@ -11,7 +11,7 @@
       digest="$(skopeo inspect --tls-verify=false "docker://${alt_image}" 2>"$LOG_FILE" | jq -r '.Digest')"
       if [[ ! ${digest} ]]; then
         handle_error "$alt_image + $image"
-        continue
+        exit 1
       else
         echo "    $digest # ${alt_image}"
       fi

--- a/dependencies/che-devfile-registry/build/scripts/write_image_digests_alternate_urls.sh
+++ b/dependencies/che-devfile-registry/build/scripts/write_image_digests_alternate_urls.sh
@@ -2,7 +2,8 @@
       echo ${image} | sed -r \
           `# for CRW images, use internal Brew versions when not yet released to RHCC` \
           -e "s|registry.redhat.io/codeready-workspaces/|registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-|g" \
-          -e "s|registry.redhat.io/codeready-workspaces/|registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-|g" \
+          `# for RHSCL images, use public one as an alternate to RHCC` \
+          -e "s|registry.redhat.io/rhscl/|registry.access.redhat.com/rhscl/|g" \
           `# for operator, replace internal container name with quay name` \
           -e "s|crw-2-rhel8-operator|operator-rhel8|g" \
           > ${tmpfile}

--- a/dependencies/che-devfile-registry/devfiles/04_nodejs-mongo/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/04_nodejs-mongo/devfile.yaml
@@ -27,7 +27,7 @@ components:
     mountSources: true
   - type: dockerimage
     alias: mongo
-    image: registry.redhat.io/rhscl/mongodb-34-rhel7:1-56
+    image: registry.redhat.io/rhscl/mongodb-34-rhel7:1-57
     memoryLimit: 512Mi
     env:
       - name: MONGODB_USER

--- a/dependencies/che-plugin-registry/build/scripts/write_image_digests_alternate_urls.sh
+++ b/dependencies/che-plugin-registry/build/scripts/write_image_digests_alternate_urls.sh
@@ -11,7 +11,7 @@
       digest="$(skopeo inspect --tls-verify=false "docker://${alt_image}" 2>"$LOG_FILE" | jq -r '.Digest')"
       if [[ ! ${digest} ]]; then
         handle_error "$alt_image + $image"
-        continue
+        exit 1
       else
         echo "    $digest # ${alt_image}"
       fi

--- a/dependencies/che-plugin-registry/build/scripts/write_image_digests_alternate_urls.sh
+++ b/dependencies/che-plugin-registry/build/scripts/write_image_digests_alternate_urls.sh
@@ -2,7 +2,8 @@
       echo ${image} | sed -r \
           `# for CRW images, use internal Brew versions when not yet released to RHCC` \
           -e "s|registry.redhat.io/codeready-workspaces/|registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-|g" \
-          -e "s|registry.redhat.io/codeready-workspaces/|registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-|g" \
+          `# for RHSCL images, use public one as an alternate to RHCC` \
+          -e "s|registry.redhat.io/rhscl/|registry.access.redhat.com/rhscl/|g" \
           `# for operator, replace internal container name with quay name` \
           -e "s|crw-2-rhel8-operator|operator-rhel8|g" \
           > ${tmpfile}


### PR DESCRIPTION
### What does this PR do?

Fail registry builds if a digest is not found. To avoid produce a registry that in fact is silently containing image references without a digest. This would make this registry broken in regard to disconnected network compatibility.

Also updated mongodb image to the `1-57` minor version according to @nickboldt suggestion.