### PR TITLE
Fail registry builds if a digest is not...

### DIFF
--- a/dependencies/che-devfile-registry/build/scripts/write_image_digests_alternate_urls.sh
+++ b/dependencies/che-devfile-registry/build/scripts/write_image_digests_alternate_urls.sh
@@ -2,6 +2,8 @@
       echo ${image} | sed -r \
           `# for CRW images, use internal Brew versions when not yet released to RHCC` \
           -e "s|registry.redhat.io/codeready-workspaces/|registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-|g" \
+          `# for RHSCL images, try non-authenticated RHCC instead of authenticated RHIO` \
+          -e "s|registry.redhat.io/rhscl/|registry.access.redhat.com/rhscl/|g" \
           `# for operator, replace internal container name with quay name` \
           -e "s|crw-2-rhel8-operator|operator-rhel8|g" \
           > ${tmpfile}
@@ -9,8 +11,21 @@
       rm -f ${tmpfile}
       digest="$(sleep 2s; skopeo inspect --tls-verify=false "docker://${alt_image}" 2>"$LOG_FILE" | jq -r '.Digest')"
       if [[ ! ${digest} ]]; then
-        handle_error "$alt_image + $image"
-        continue
+        # if couldn't find in public RHCC or RHIO, try internal image in registry-proxy.engineering.redhat.com/rh-osbs/
+        echo ${image} | sed -r \
+                  -e "s|registry.redhat.io/([^/]+)/|registry-proxy.engineering.redhat.com/rh-osbs/\1-|g" \
+                  -e "s|registry.access.redhat.com/([^/]+)/|registry-proxy.engineering.redhat.com/rh-osbs/\1-|g" \
+                  > ${tmpfile}
+        alt_image2=$(cat ${tmpfile})
+        rm -f ${tmpfile}
+        digest="$(sleep 2s; skopeo inspect --tls-verify=false "docker://${alt_image2}" 2>"$LOG_FILE" | jq -r '.Digest')"
+        if [[ ! ${digest} ]]; then
+          # could not find digest, so fail
+          handle_error "$alt_image2 + $alt_image + $image"
+          exit 1
+        else
+          echo "    $digest # ${alt_image2}"
+        fi
       else
         echo "    $digest # ${alt_image}"
       fi

--- a/dependencies/che-devfile-registry/devfiles/04_nodejs-mongo/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/04_nodejs-mongo/devfile.yaml
@@ -27,7 +27,7 @@ components:
     mountSources: true
   - type: dockerimage
     alias: mongo
-    image: registry.redhat.io/rhscl/mongodb-34-rhel7:1-56
+    image: registry.redhat.io/rhscl/mongodb-34-rhel7:1-57
     memoryLimit: 512Mi
     env:
       - name: MONGODB_USER

--- a/dependencies/che-plugin-registry/build/scripts/write_image_digests_alternate_urls.sh
+++ b/dependencies/che-plugin-registry/build/scripts/write_image_digests_alternate_urls.sh
@@ -2,6 +2,8 @@
       echo ${image} | sed -r \
           `# for CRW images, use internal Brew versions when not yet released to RHCC` \
           -e "s|registry.redhat.io/codeready-workspaces/|registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-|g" \
+          `# for RHSCL images, try non-authenticated RHCC instead of authenticated RHIO` \
+          -e "s|registry.redhat.io/rhscl/|registry.access.redhat.com/rhscl/|g" \
           `# for operator, replace internal container name with quay name` \
           -e "s|crw-2-rhel8-operator|operator-rhel8|g" \
           > ${tmpfile}
@@ -9,8 +11,21 @@
       rm -f ${tmpfile}
       digest="$(sleep 2s; skopeo inspect --tls-verify=false "docker://${alt_image}" 2>"$LOG_FILE" | jq -r '.Digest')"
       if [[ ! ${digest} ]]; then
-        handle_error "$alt_image + $image"
-        continue
+        # if couldn't find in public RHCC or RHIO, try internal image in registry-proxy.engineering.redhat.com/rh-osbs/
+        echo ${image} | sed -r \
+                  -e "s|registry.redhat.io/([^/]+)/|registry-proxy.engineering.redhat.com/rh-osbs/\1-|g" \
+                  -e "s|registry.access.redhat.com/([^/]+)/|registry-proxy.engineering.redhat.com/rh-osbs/\1-|g" \
+                  > ${tmpfile}
+        alt_image2=$(cat ${tmpfile})
+        rm -f ${tmpfile}
+        digest="$(sleep 2s; skopeo inspect --tls-verify=false "docker://${alt_image2}" 2>"$LOG_FILE" | jq -r '.Digest')"
+        if [[ ! ${digest} ]]; then
+          # could not find digest, so fail
+          handle_error "$alt_image2 + $alt_image + $image"
+          exit 1
+        else
+          echo "    $digest # ${alt_image2}"
+        fi
       else
         echo "    $digest # ${alt_image}"
       fi


### PR DESCRIPTION
Fail registry builds if a digest is not found

Signed-off-by: David Festal <dfestal@redhat.com>

Try `registry.access.redhat.com` for rhscl images; fall back to registry-proxy.engineering.redhat.com/rh-osbs/ if could not resolve digest from public registries

Change-Id: I21e6ceb028eb76aa8d6d4b3fcda675cc38b1c5ee
Signed-off-by: David Festal <dfestal@redhat.com>