### PR TITLE
CRW-784 fix che-plugin-registry/.gitignore...

### DIFF
--- a/dependencies/che-plugin-registry/.gitignore
+++ b/dependencies/che-plugin-registry/.gitignore
@@ -20,5 +20,5 @@ test-output/
 che-dto.ts
 resources/
 /root-local.tgz
-/v3.tgz
+/resources.tgz
 airgap.Dockerfile


### PR DESCRIPTION
CRW-784 fix che-plugin-registry/.gitignore since v3.tgz is now resources.tgz

Change-Id: I83e234d6c6d3d74c5d58cc2df617f5778a379d6d
Signed-off-by: nickboldt <nboldt@redhat.com>