### PR TITLE
[CRW 2.2] Update c++ devfile to use new sample

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/05_cpp/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_cpp/devfile.yaml
@@ -4,10 +4,10 @@ metadata:
   generateName: cpp-
 projects:
   -
-    name: cpp-hello-world
+    name: C-Plus-Plus
     source:
       type: git
-      location: 'https://github.com/che-samples/cpp-hello-world'
+      location: 'https://github.com/crw-samples/C-Plus-Plus.git'
 components:
 -
   type: chePlugin
@@ -24,21 +24,21 @@ components:
   mountSources: true
 commands:
   -
-    name: build
+    name: Build current algorithm
     actions:
       - type: exec
         component: cpp-dev
-        command: g++ -g hello.cpp -o hello.out && echo "Build complete"
-        workdir: ${CHE_PROJECTS_ROOT}/cpp-hello-world
+        command: rm -f "${fileDirname}"/bin.out && g++ -g "${file}" -o bin.out && echo "Build complete"
+        workdir: '${fileDirname}'
   -
-    name: run
+    name: Run current algorithm
     actions:
       - type: exec
         component: cpp-dev
-        command: ./hello.out
-        workdir: ${CHE_PROJECTS_ROOT}/cpp-hello-world
+        command: ./bin.out
+        workdir: '${fileDirname}'
   -
-    name: debug
+    name: Debug current algorithm
     actions:
       - type: vscode-launch
         referenceContent: >
@@ -47,9 +47,9 @@ commands:
             "configurations": [
                 {
                     "type": "gdb",
-                    "name": "Debug c++ application",
+                    "name": "Debug current algorithm",
                     "request": "launch",
-                    "program": "/projects/cpp-hello-world/hello.out"
+                    "program": "${fileDirname}/bin.out"
                 }
             ]
           }

--- a/dependencies/che-devfile-registry/devfiles/05_cpp/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_cpp/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
   generateName: cpp-
 projects:
   -
-    name: C-Plus-Plus
+    name: CPP
     source:
       type: git
       location: 'https://github.com/crw-samples/C-Plus-Plus.git'


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Updates existing cpp devfile by replacing cpp-hello-world example with https://github.com/crw-samples/C-Plus-Plus
![screenshot-codeready-vsvydenko-crw apps ocp44 codereadyqe com-2020 04 08-16_15_52](https://user-images.githubusercontent.com/1271546/78788288-43652e00-79b4-11ea-806b-7a9f0cfd4785.png)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-740

