### PR TITLE
Add debug configuration and command to run application

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/04_nodejs-configmap/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/04_nodejs-configmap/devfile.yaml
@@ -17,6 +17,9 @@ components:
     type: dockerimage
     alias: nodejs
     image: registry.redhat.io/codeready-workspaces/stacks-node-rhel8:2.1
+    endpoints:
+      - name: "nodejs"
+        port: 8080
   - id: redhat/vscode-openshift-connector/latest
     type: chePlugin
     alias: openshift-connector
@@ -28,9 +31,33 @@ commands:
         type: exec
         command: npm install
         component: nodejs
-  - name: 2. Deploy application
+  - name: 2. Run application
+    actions:
+      - workdir: "${CHE_PROJECTS_ROOT}/nodejs-configmap"
+        type: exec
+        command: node --inspect=9229 .
+        component: nodejs
+  - name: 3. Deploy application
     actions:
       - workdir: "${CHE_PROJECTS_ROOT}/nodejs-configmap"
         type: exec
         command: npm run openshift
         component: nodejs
+  - name: Attach remote debugger
+    actions:
+      - type: vscode-launch
+        referenceContent: |
+          {
+            "version": "0.2.0",
+            "configurations": [
+              {
+                "type": "node",
+                "request": "attach",
+                "name": "Attach to Remote",
+                "address": "localhost",
+                "port": 9229,
+                "localRoot": "${workspaceFolder}",
+                "remoteRoot": "${workspaceFolder}"
+              }
+            ]
+          }


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Add debug configuration and command to run application into nodejs-configmap devfile
![screenshot-codeready-crw-crwctl-no-tls-no-oauth apps ocp44 codereadyqe com-2020 05 04-13_24_49](https://user-images.githubusercontent.com/1271546/80956835-ace92880-8e0a-11ea-8428-48dcf3447c8a.png)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-791

