### PR TITLE
Add 'python.globalModuleInstallation: true' pref to python devfile

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/05_python/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_python/devfile.yaml
@@ -12,6 +12,8 @@ components:
   -
     type: chePlugin
     id: ms-python/python/latest
+    preferences:
+      python.globalModuleInstallation: true
     memoryLimit: 512Mi
   -
     type: dockerimage


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Activates global module installation mode for Python extension in Python devfile

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-886
