### PR TITLE
Update MongoDB image from 3.4 to 3.6

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/04_nodejs-mongo/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/04_nodejs-mongo/devfile.yaml
@@ -27,7 +27,7 @@ components:
     mountSources: true
   - type: dockerimage
     alias: mongo
-    image: registry.redhat.io/rhscl/mongodb-34-rhel7:1-57
+    image: registry.redhat.io/rhscl/mongodb-36-rhel7:1-50
     memoryLimit: 512Mi
     env:
       - name: MONGODB_USER
@@ -42,7 +42,7 @@ components:
       - name: mongo-storage
         containerPath: /var/lib/mongodb/data
     endpoints:
-      - name: mongodb-34-rhel7
+      - name: mongodb-36-rhel7
         port: 27017
         attributes:
           discoverable: "true"


### PR DESCRIPTION
Mirrors the upstream change and supports multi-arch.
Fixes https://issues.redhat.com/browse/CRW-884

Signed-off-by: Eric Williams <ericwill@redhat.com>