### PR TITLE
Use 7.13.0 Dashboard and workspace-loader as docker containers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,24 +155,32 @@ timeout(240) {
 		// apply CRW CSS
 		sh '''#!/bin/bash -xe
 			rawBranch=${branchToBuildCRW##*/}
-			curl -S -L --create-dirs -o ''' + CHE_DB_path + '''/src/assets/branding/branding.css \
+			curl -sSL --create-dirs -o ''' + CHE_DB_path + '''/src/assets/branding/branding.css \
 				https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/${rawBranch}/assembly/codeready-workspaces-assembly-dashboard-war/src/main/webapp/assets/branding/branding-crw.css
-			cat ''' + CHE_DB_path + '''/src/assets/branding/branding.css
+			# cat ''' + CHE_DB_path + '''/src/assets/branding/branding.css
 		'''
-		sh "cp ${CRW_path}/assembly/assembly-codeready-workspaces-assembly-dashboard/src/main/webapp/assets/branding dashboard/assets/branding"
 
-		// process product.json template
-		sh "cp dashboard/assets/branding/product.json.template dashboard/assets/branding/product.json"
-		sh "sed -i -e \"s#@@crw.version@@#${CRW_SHAs}#g\" dashboard/assets/branding/product.json"
-		
-		DOCS_VERSION = sh(returnStdout:true,script:"mvn ${MVN_FLAGS} -f ${CRW_path}/pom.xml help:evaluate -Dexpression=crw.docs.version | grep "^[^\[]" ")
-		CRW_DOCS_BASEURL="https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/" + DOCS_VERSION
-		sh "sed -i -e \"s#@@crw.docs.baseurl@@#${CRW_DOCS_BASEURL}#g\" dashboard/assets/branding/product.json"
+		DOCS_VERSION = sh(returnStdout:true,script:"grep crw.docs.version ${CRW_path}/pom.xml | sed -r -e \"s#.*<.+>([0-9.SNAPSHOT-]+)</.+>#\\1#\"")
+		def CRW_DOCS_BASEURL = ("https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/" + DOCS_VERSION).trim()
+		echo "CRW_DOCS_BASEURL = ${CRW_DOCS_BASEURL}"
 
 		sh '''#!/bin/bash -xe
-			docker build -f apache.Dockerfile -t che-dashboard:tmp.
-			docker create -ti --name dashboard-container crw-dashboard:tmp bash
-			docker cp dashboard-container:/usr/local/apache2/htdocs/dashboard dashboard
+		cd ''' + CHE_DB_path + '''
+		# ls -la src/assets/branding/
+		rsync -aPr ../''' + CRW_path + '''/assembly/codeready-workspaces-assembly-dashboard-war/src/main/webapp/assets/branding/* src/assets/branding/
+		# ls -la src/assets/branding/
+		mv -f src/assets/branding/branding{-crw,}.css
+
+		# process product.json template
+        sed -r \
+          -e "s#@@crw.version@@#'''+CRW_SHAs + '''#g" \
+ 		  -e "s#@@crw.docs.baseurl@@#''' + CRW_DOCS_BASEURL + '''#g" \
+        src/assets/branding/product.json.template > src/assets/branding/product.json
+		rm -f src/assets/branding/product.json.template
+		# cat src/assets/branding/product.json
+	
+		docker build -f apache.Dockerfile -t crw-dashboard:tmp .
+		docker run --rm --entrypoint sh crw-dashboard:tmp -c 'tar -pzcf - /usr/local/apache2/htdocs/dashboard' > asset-dashboard.tar.gz
 		'''
 
 		echo "<===== Build che-dashboard ====="
@@ -190,9 +198,9 @@ timeout(240) {
 		SHA_CHE_WL = sh(returnStdout:true,script:"cd ${CHE_WL_path}/ && git rev-parse --short=4 HEAD").trim()
 		
 		sh '''#!/bin/bash -xe
-			docker build -f apache.Dockerfile -t che-workspace-loader:tmp .
-			docker create -ti --name workspace-loader-container che-workspace-loader:tmp bash
-			docker cp workspace-loader-container:/usr/local/apache2/htdocs/workspace-loader workspace-loader
+			cd ''' + CHE_WL_path + '''
+			docker build -f apache.Dockerfile -t crw-workspace-loader:tmp .
+			docker run --rm --entrypoint sh crw-workspace-loader:tmp -c 'tar -pzcf - /usr/local/apache2/htdocs/workspace-loader' > asset-workspace-loader.tar.gz
 		'''
 
 		echo "<===== Build che-workspace-loader ====="
@@ -225,12 +233,37 @@ timeout(240) {
 		// NOTE: VER_CHE could be 7.12.2-SNAPSHOT if we're using a .x branch instead of a tag. So this overrides what's in the crw root pom.xml
 		sh "mvn clean install ${MVN_FLAGS} -f ${CRW_path}/pom.xml -Dparent.version=\"${VER_CHE}\" -Dche.version=\"${VER_CHE}\" -Dcrw.dashboard.version=\"${CRW_SHAs}\" ${MVN_EXTRA_FLAGS}"
 
-		// Add dashboard and workspace-loader that were built in container earlier
-		sh "gunzip ${CRW_path}/assembly/${CRW_path}-assembly-main/target/*.tar.*"
-		sh "tar rvf ${CRW_path}/assembly/${CRW_path}-assembly-main/target/*.tar --transform 's,^,codeready-workspaces-assembly-main/tomcat/webapps,'"
-		sh "gzip ${CRW_path}/assembly/${CRW_path}-assembly-main/target/*.tar"
+		// Add dashboard and workspace-loader to server assembly
+		sh '''#!/bin/bash -xe
+			# unpack incomplete assembly
+			mkdir -p /tmp/''' + CRW_path + '''-assembly-main/tomcat/webapps/dashboard/ /tmp/''' + CRW_path + '''-assembly-main/tomcat/webapps/workspace-loader/
+			tar xvzf ''' + CRW_path + '''/assembly/''' + CRW_path + '''-assembly-main/target/codeready-workspaces-assembly-main.tar.gz -C /tmp/''' + CRW_path + '''-assembly-main/
 
-		archiveArtifacts fingerprint: true, artifacts:"**/*.log, **/assembly/*xml, **/assembly/**/*xml, ${CRW_path}/assembly/${CRW_path}-assembly-main/target/*.tar.*"
+			# rename incomplete assembly
+			mv ''' + CRW_path + '''/assembly/''' + CRW_path + '''-assembly-main/target/codeready-workspaces-assembly-main{,-no-dashboard-no-workspace-loader}.tar.gz 
+
+			# unpack + move dashboard artifacts
+			tar xvzf ''' + CHE_DB_path + '''/asset-dashboard.tar.gz -C /tmp/''' + CRW_path + '''-assembly-main/tomcat/webapps/dashboard/
+			mv /tmp/''' + CRW_path + '''-assembly-main/tomcat/webapps/dashboard/usr/local/apache2/htdocs/dashboard/* \
+			   /tmp/''' + CRW_path + '''-assembly-main/codeready-workspaces-assembly-main/tomcat/webapps/dashboard/
+
+			# unpack + move workspace-loader artifacts
+			tar xvzf ''' + CHE_WL_path + '''/asset-workspace-loader.tar.gz -C /tmp/''' + CRW_path + '''-assembly-main/tomcat/webapps/workspace-loader/
+			mv /tmp/''' + CRW_path + '''-assembly-main/tomcat/webapps/workspace-loader/usr/local/apache2/htdocs/workspace-loader/* \
+			   /tmp/''' + CRW_path + '''-assembly-main/codeready-workspaces-assembly-main/tomcat/webapps/workspace-loader/
+
+			# clean up temp folder
+			rm -fr /tmp/''' + CRW_path + '''-assembly-main/tomcat/
+
+			# build new complete tarball assemlby with che server, dashboard, and workspace-loader
+			pushd /tmp/''' + CRW_path + '''-assembly-main/ >/dev/null; tar -pzcf codeready-workspaces-assembly-main.tar.gz ./*; popd >/dev/null
+			mv /tmp/''' + CRW_path + '''-assembly-main/codeready-workspaces-assembly-main.tar.gz ''' + CRW_path + '''/assembly/''' + CRW_path + '''-assembly-main/target/
+
+			# clean up incomplete assembly
+			rm -f ''' + CRW_path + '''/assembly/''' + CRW_path + '''-assembly-main/target/codeready-workspaces-assembly-main-no-dashboard-no-workspace-loader.tar.gz
+		'''
+
+		archiveArtifacts fingerprint: true, artifacts:"**/*.log, **/assembly/*xml, **/assembly/**/*xml, ${CRW_path}/assembly/${CRW_path}-assembly-main/target/*.tar.*, **/asset-*.gz"
 
 		echo "<===== Build CRW server assembly ====="
 

--- a/assembly/codeready-workspaces-assembly-dashboard-war/src/main/webapp/assets/branding/product.json.template
+++ b/assembly/codeready-workspaces-assembly-dashboard-war/src/main/webapp/assets/branding/product.json.template
@@ -12,18 +12,28 @@
   "supportEmail": "codeready-workspaces-wish@redhat.com",
   "oauthDocs": "Configure GitHub OAuth in RH SSO realm settings",
   "workspace": {
-    "priorityStacks": ["JBoss EAP", "Java 1.8", "Vert.x", "Spring Boot", "Wildfly Swarm", "Red Hat Fuse"],
-    "defaultStack": "eap-default"
+    "priorityStacks": [
+      "JBoss EAP", 
+      "Java", 
+      "Vert.x", 
+      "Spring Boot", 
+      "Wildfly Swarm", 
+      "Red Hat Fuse"
+    ],
+    "defaultStack": "eap-default",
+    "creationLink": "#/getstarted?tab=customWorkspace"
   },
-  "cli" : {
-    "configName" : "che.env",
-    "name" : "CHE"
+  "cli": {
+    "configName": "che.env",
+    "name": "CHE"
   },
-  "docs" : {
+  "docs": {
     "devfile" : "@@crw.docs.baseurl@@/html/end-user_guide/workspaces-overview#configuring-a-workspace-using-a-devfile_crw",
     "workspace" : "@@crw.docs.baseurl@@/html/end-user_guide/workspaces-overview",
     "factory" : "@@crw.docs.baseurl@@/html/end-user_guide/workspaces-overview#configuring-a-workspace-using-a-devfile_crw",
+    "organization": "@@crw.docs.baseurl@@/html/administration_guide/managing-users_crw#using-organizations_crw",
     "converting": "@@crw.docs.baseurl@@/html/end-user_guide/workspaces-overview#converting-a-codeready-workspaces-1.2-workspace-to-a-codeready-workspaces-2.0-devfile",
+    "certificate": "@@crw.docs.baseurl@@/html/installation_guide/advanced-configuration-options_crw#deploying-codeready-workspaces-with-support-for-git-repositories-with-self-signed-certificates_advanced-configuration-options",
     "general": "@@crw.docs.baseurl@@/html"
   }
 }

--- a/assembly/codeready-workspaces-assembly-main/pom.xml
+++ b/assembly/codeready-workspaces-assembly-main/pom.xml
@@ -26,13 +26,6 @@
     <properties>
         <jbossNexus>repository.jboss.org</jbossNexus>
     </properties>
-    <dependencies>
-        <dependency>
-            <groupId>com.redhat</groupId>
-            <artifactId>codeready-workspaces-assembly-dashboard-war</artifactId>
-            <type>war</type>
-        </dependency>
-    </dependencies>
     <build>
         <plugins>
             <plugin>

--- a/assembly/codeready-workspaces-assembly-main/src/assembly/assembly.xml
+++ b/assembly/codeready-workspaces-assembly-main/src/assembly/assembly.xml
@@ -18,18 +18,6 @@
         <format>dir</format>
         <format>tar.gz</format>
     </formats>
-    <dependencySets>
-        <dependencySet>
-            <useProjectArtifact>false</useProjectArtifact>
-            <unpack>false</unpack>
-            <outputDirectory>tomcat/webapps</outputDirectory>
-            <outputFileNameMapping>dashboard.war</outputFileNameMapping>
-            <includes>
-                <include>com.redhat:codeready-workspaces-assembly-dashboard-war</include>
-            </includes>
-        </dependencySet>
-    </dependencySets>
-
     <fileSets>
         <fileSet>
             <directory>${project.build.directory}/dependency/eclipse-che-${che.version}</directory>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -24,7 +24,6 @@
     <packaging>pom</packaging>
     <name>CRW :: Assembly :: Parent</name>
     <modules>
-        <module>codeready-workspaces-assembly-dashboard-war</module>
         <module>codeready-workspaces-assembly-main</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.redhat</groupId>
-                <artifactId>codeready-workspaces-assembly-dashboard-war</artifactId>
-                <version>${crw.version}</version>
-                <type>war</type>
-            </dependency>
-            <dependency>
                 <groupId>org.eclipse.che</groupId>
                 <artifactId>che-parent</artifactId>
                 <version>${che.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
         <artifactId>maven-parent-pom</artifactId>
         <groupId>org.eclipse.che.parent</groupId>
         as of Che 7.13 -->
-        <artifactId>maven-depmgt-pom</artifactId>
-        <groupId>org.eclipse.che.depmgt</groupId>
-        <version>7.12.1</version>
+        <artifactId>maven-parent-pom</artifactId>
+        <groupId>org.eclipse.che.parent</groupId>
+        <version>7.13.0</version>
     </parent>
     <groupId>com.redhat</groupId>
     <artifactId>codeready</artifactId>
@@ -42,7 +42,7 @@
     </modules>
     <properties>
         <che.dashboard.version>${che.version}</che.dashboard.version>
-        <che.version>7.12.1</che.version>
+        <che.version>7.13.0</che.version>
         <crw.dashboard.version>${crw.version} (Eclipse Che ${che.version})</crw.dashboard.version>
         <crw.docs.version>2.2</crw.docs.version>
         <crw.version>${project.version}</crw.version>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Dashboard and workspace loader, which are not a part of original maven artifacts, are now built as containers, and then injected into CRWs assembly-main

### What issues does this PR fix or reference?
CRW-881

TODO
make sure things from CRW repo are accessed after it has been checked out

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
