### PR TITLE
CRW-871 remove refs to stack-analysis.sh; switch to using OSBS builds of EAP 7.3.1/XP1.0; for Fuse, use JDK 8; for the rest switch to JDK 11

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/devfile.yaml
@@ -11,11 +11,17 @@ projects:
 components:
   -
     type: chePlugin
-    id: redhat/java8/latest
+    id: redhat/java11/latest
+  -
+    # NOTE: instead of the old stack-analysis script, should be able to use the latest dependency-analysis plugin instead
+    type: chePlugin
+    id: redhat/dependency-analytics/latest
   -
     type: dockerimage
     alias: maven
-    image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8:2.2
+    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
+    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
+    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
     env:
       - name: MAVEN_OPTS
         value: "-Xmx200m -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"
@@ -64,13 +70,6 @@ commands:
         component: maven
         command: "mvn clean install && cp target/*.war /opt/eap/standalone/deployments/ROOT.war"
         workdir: ${CHE_PROJECTS_ROOT}/kitchensink-example
-  -
-    name: dependency analysis
-    actions:
-      -
-        type: exec
-        component: maven
-        command: "${HOME}/stack-analysis.sh -f ${CHE_PROJECTS_ROOT}/kitchensink-example/pom.xml -p ${CHE_PROJECTS_ROOT}/kitchensink-example"
   -
     name: Debug (Attach)
     actions:

--- a/dependencies/che-devfile-registry/devfiles/01_java-eap-thorntail/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/01_java-eap-thorntail/devfile.yaml
@@ -11,11 +11,17 @@ projects:
 components:
   -
     type: chePlugin
-    id: redhat/java8/latest
+    id: redhat/java11/latest
+  -
+    # NOTE: instead of the old stack-analysis script, should be able to use the latest dependency-analysis plugin instead
+    type: chePlugin
+    id: redhat/dependency-analytics/latest
   -
     type: dockerimage
     alias: maven
-    image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8:2.2
+    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
+    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
+    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
     env:
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"
@@ -62,13 +68,6 @@ commands:
         component: maven
         command: "mvn fabric8:deploy -Popenshift -DskipTests"
         workdir: ${CHE_PROJECTS_ROOT}/rest-http-redhat
-  -        
-    name: dependency analysis
-    actions:
-      -
-        type: exec
-        component: maven
-        command: "${HOME}/stack-analysis.sh -f ${CHE_PROJECTS_ROOT}/rest-http-redhat/pom.xml -p ${CHE_PROJECTS_ROOT}/rest-http-redhat"
   -
     name: Debug (Attach)
     actions:

--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
@@ -16,9 +16,18 @@ components:
     type: chePlugin
     id: redhat/vscode-apache-camel/latest
   -
+    # NOTE: instead of the old stack-analysis script, should be able to use the latest dependency-analysis plugin instead
+    type: chePlugin
+    id: redhat/dependency-analytics/latest
+  -
     type: dockerimage
     alias: maven
-    image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8:2.2
+    # NOTE: Need EAP 7.3 RHEL 7 / JDK 8 image for Fuse support (not RHEL 8 / JDK 11)
+    # NOTE: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7 == 7.3.0, but we can use the newer 7.3.1 / XP 1.0 image (CRW-876, CRW-871)
+
+    # TODO: For Z and Power, likely need to switch at build time to an openj9-8 image, if it exists (CRW-758)
+    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk8-openshift-rhel7:1.0 when it's live (June 1?)
+    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk8-openshift-rhel7:latest
     env:
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
@@ -42,7 +51,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "MAVEN_OPTS='-Xmx200m' && mvn clean package"
+        command: "MAVEN_OPTS='-Xmx200m' && scl enable rh-maven35 'mvn clean package'"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: run app
@@ -50,7 +59,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "mvn spring-boot:run"
+        command: "scl enable rh-maven35 'mvn spring-boot:run'"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: deploy to OpenShift
@@ -58,23 +67,15 @@ commands:
       -
         type: exec
         component: maven
-        command: "mvn fabric8:deploy -Popenshift -DskipTests"
+        command: "scl enable rh-maven35 'mvn fabric8:deploy -Popenshift -DskipTests'"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
-  -
-    name: dependency analysis
-    actions:
-        -
-          type: exec
-          component: maven
-          command: "${HOME}/stack-analysis.sh -f ${CHE_PROJECTS_ROOT}/java-jboss-fuse/pom.xml -p ${CHE_PROJECTS_ROOT}/java-jboss-fuse"
-          workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: debug
     actions:
       -
         type: exec
         component: maven
-        command: "mvn spring-boot:run -Drun.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\""
+        command: "scl enable rh-maven35 'mvn spring-boot:run -Drun.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\"'"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: Debug remote java application

--- a/dependencies/che-devfile-registry/devfiles/02_java-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-maven/devfile.yaml
@@ -11,11 +11,17 @@ projects:
 components:
   -
     type: chePlugin
-    id: redhat/java8/latest
+    id: redhat/java11/latest
+  -
+    # NOTE: instead of the old stack-analysis script, should be able to use the latest dependency-analysis plugin instead
+    type: chePlugin
+    id: redhat/dependency-analytics/latest
   -
     type: dockerimage
     alias: maven
-    image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8:2.2
+    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
+    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
+    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
     env:
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"
@@ -67,13 +73,6 @@ commands:
         type: exec
         command: "mvn fabric8:deploy -Popenshift -DskipTests -Dvertx.disableDnsResolver=true"
         component: maven
-  -  
-    name: Dependency analysis
-    actions:
-      -
-        type: exec
-        component: maven
-        command: "${HOME}/stack-analysis.sh -f ${CHE_PROJECTS_ROOT}/vertx-health-checks-example-redhat/pom.xml -p ${CHE_PROJECTS_ROOT}/vertx-health-checks-example-redhat"
   -
     name: Attach remote debugger
     actions:

--- a/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
@@ -8,9 +8,10 @@ projects:
       type: git
       branch: master
 components:
-  - id: redhat/java8/latest
+  - id: redhat/java11/latest
     type: chePlugin
   - id: redhat/dependency-analytics/latest
+    # NOTE: instead of the old stack-analysis script, should be able to use the latest dependency-analysis plugin instead
     type: chePlugin
   - mountSources: true
     endpoints:
@@ -22,7 +23,9 @@ components:
       - name: m2
         containerPath: /home/jboss/.m2
     alias: maven
-    image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8:2.2
+    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
+    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
+    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
     env:
       - value: >-
           -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
@@ -75,15 +78,6 @@ commands:
       - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec
         command: 'MAVEN_OPTS="-Xmx200m" && mvn -Duser.home=${HOME} verify'
-        component: maven
-  - name: dependency-analysis
-    actions:
-      - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
-        type: exec
-        command: >-
-          ${HOME}/stack-analysis.sh -f
-          ${CHE_PROJECTS_ROOT}/spring-boot-http-booster/pom.xml -p
-          ${CHE_PROJECTS_ROOT}/spring-boot-http-booster
         component: maven
   - name: deploy to OpenShift
     actions:

--- a/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/devfile.yaml
@@ -8,9 +8,10 @@ projects:
       type: git
       branch: master
 components:
-  - id: redhat/java8/latest
+  - id: redhat/java11/latest
     type: chePlugin
   - id: redhat/dependency-analytics/latest
+    # NOTE: instead of the old stack-analysis script, should be able to use the latest dependency-analysis plugin instead
     type: chePlugin
   - mountSources: true
     endpoints:
@@ -22,7 +23,9 @@ components:
       - name: m2
         containerPath: /home/jboss/.m2
     alias: maven
-    image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8:2.2
+    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
+    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
+    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
     env:
       - value: >-
           -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10


### PR DESCRIPTION
CRW-871 remove refs to stack-analysis.sh; switch to using OSBS builds of EAP 7.3.1/XP1.0; for Fuse, use JDK 8; for the rest switch to JDK 11

Change-Id: I498cea8df63b3591a4f7837e5f4fb1664f25cdb3
Signed-off-by: nickboldt <nboldt@redhat.com>