### PR TITLE
generate ssl cert when basing from httpd container

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/rhel.Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/rhel.Dockerfile
@@ -77,6 +77,7 @@ FROM registry.access.redhat.com/rhscl/httpd-24-rhel7:2.4-114 AS registry
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/rhel8/httpd-24
 # FROM registry.redhat.io/rhel8/httpd-24:1-92 AS registry
 USER 0
+RUN chmod +x /usr/share/container-scripts/httpd/pre-init/40-ssl-certs.sh && /usr/share/container-scripts/httpd/pre-init/40-ssl-certs.sh
 RUN yum update -y systemd && yum clean all && rm -rf /var/cache/yum && \
     echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?

generate ssl cert when basing from httpd container

### What issues does this PR fix or reference?

when upgrading from httpd-24:89 to httpd-24:91 the cert specified in ssl.conf does not exist.

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
