### PR TITLE
Update java-based stacks to use EAP-7.3.x and plugin-java8-rhel8 images

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/devfile.yaml
@@ -19,9 +19,12 @@ components:
   -
     type: dockerimage
     alias: maven
-    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
-    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
-    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
+    # NOTE: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
+    # NOTE: can test pre-release image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
+    # NOTE: there's also a JDK8 version at registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:7.3.0 ...
+    #       BUT the JDK8/RHEL7 image requires using "scl enable rh-maven35 'mvn -version'" to run maven, so devfile will need adjustment.
+    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live
+    image: registry.redhat.io/jboss-eap-7/eap73-openjdk11-openshift-rhel8:7.3.0
     env:
       - name: MAVEN_OPTS
         value: "-Xmx200m -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"

--- a/dependencies/che-devfile-registry/devfiles/01_java-eap-thorntail/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/01_java-eap-thorntail/meta.yaml
@@ -1,6 +1,0 @@
----
-displayName: Java EAP Thorntail
-description: Quickstart to expose a REST Greeting endpoint using Thorntail with EAP 7.2.7, OpenJDK 1.8 and Maven 3.5.4
-tags: ["RHEL8", "Java", "OpenJDK", "Maven", "EAP", "Thorntail"]
-icon: /images/type-thorntail.svg
-globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/01_java-thorntail/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/01_java-thorntail/devfile.yaml
@@ -11,7 +11,7 @@ projects:
 components:
   -
     type: chePlugin
-    id: redhat/java11/latest
+    id: redhat/java8/latest
   -
     # NOTE: instead of the old stack-analysis script, should be able to use the latest dependency-analysis plugin instead
     type: chePlugin
@@ -19,8 +19,8 @@ components:
   -
     type: dockerimage
     alias: maven
-    # image: quay.io/crw/plugin-java11-rhel8:latest
-    image: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2
+    # image: quay.io/crw/plugin-java8-rhel8:2.2
+    image: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8:2.2
     env:
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"

--- a/dependencies/che-devfile-registry/devfiles/01_java-thorntail/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/01_java-thorntail/devfile.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  generateName: java-eap-thorntail-
+  generateName: java-thorntail-
 projects:
   -
     name: rest-http-redhat
@@ -19,9 +19,8 @@ components:
   -
     type: dockerimage
     alias: maven
-    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
-    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
-    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
+    # image: quay.io/crw/plugin-java11-rhel8:latest
+    image: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2
     env:
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"
@@ -29,7 +28,7 @@ components:
         value: $(JAVA_OPTS)
     memoryLimit: 768Mi
     endpoints:
-      - name: 'eap'
+      - name: '8080'
         port: 8080
     mountSources: true
     volumes:

--- a/dependencies/che-devfile-registry/devfiles/01_java-thorntail/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/01_java-thorntail/meta.yaml
@@ -1,0 +1,6 @@
+---
+displayName: Java EAP Thorntail
+description: Quickstart to expose a REST Greeting endpoint using Thorntail with EAP 7.2.7, OpenJDK 11 and Maven 3.6.3
+tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Thorntail"]
+icon: /images/type-thorntail.svg
+globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/01_java-thorntail/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/01_java-thorntail/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Java EAP Thorntail
-description: Quickstart to expose a REST Greeting endpoint using Thorntail with EAP 7.2.7, OpenJDK 11 and Maven 3.6.3
+description: Quickstart to expose a REST Greeting endpoint using Thorntail with EAP 7.2.7, OpenJDK 8 and Maven 3.6.3
 tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Thorntail"]
 icon: /images/type-thorntail.svg
 globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
@@ -7,7 +7,7 @@ projects:
     name: java-jboss-fuse
     source:
       type: git
-      location: "https://github.com/crw-samples/fuse-rest-http-booster/"
+      location: 'https://github.com/jboss-fuse/fuse-rest-http-booster/'
 components:
   -
     type: chePlugin
@@ -32,7 +32,7 @@ components:
     type: dockerimage
     alias: maven
     # might be able to use JDK 11 here but 8 is multi-arch too (x86_64, s390x, ppc64le)
-    image: registry.redhat.io/ubi8/openjdk-8:1.3
+    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk8-openshift-rhel7:latest
     env:
       - name: MAVEN_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
@@ -54,7 +54,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "MAVEN_OPTS='-Xmx200m' && mvn clean package"
+        command: "MAVEN_OPTS='-Xmx200m' && scl enable rh-maven35 'mvn clean package'"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: run app
@@ -62,7 +62,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "mvn spring-boot:run"
+        command: "scl enable rh-maven35 'mvn spring-boot:run -Drun.jvmArguments='-Dserver.port=8000''"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: deploy to OpenShift
@@ -78,7 +78,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "mvn spring-boot:run -Drun.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\""
+        command: "scl enable rh-maven35 'mvn spring-boot:run -Drun.jvmArguments=\"-Dserver.port=8000 -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\"'"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: Debug remote java application

--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
@@ -7,7 +7,7 @@ projects:
     name: java-jboss-fuse
     source:
       type: git
-      location: "https://github.com/jboss-fuse/fuse-rest-http-booster/"
+      location: "https://github.com/crw-samples/fuse-rest-http-booster/"
 components:
   -
     type: chePlugin
@@ -21,6 +21,15 @@ components:
     id: redhat/dependency-analytics/latest
   -
     type: dockerimage
+    mountSources: true
+    memoryLimit: 512Mi
+    volumes:
+      - name: m2
+        containerPath: /home/jboss/.m2
+    image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2'
+    alias: deployment
+  -
+    type: dockerimage
     alias: maven
     # NOTE: Need EAP 7.3 RHEL 7 / JDK 8 image for Fuse support (not RHEL 8 / JDK 11)
     # NOTE: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7 == 7.3.0, but we can use the newer 7.3.1 / XP 1.0 image (CRW-876, CRW-871)
@@ -29,17 +38,15 @@ components:
     # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk8-openshift-rhel7:1.0 when it's live (June 1?)
     image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk8-openshift-rhel7:latest
     env:
-      - name: JAVA_OPTS
+      - name: MAVEN_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
           -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
           -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
           -Duser.home=/home/jboss"
-      - name: MAVEN_OPTS
-        value: $(JAVA_OPTS)
     memoryLimit: 768Mi
     endpoints:
-      - name: '8080'
-        port: 8080
+      - name: '8000'
+        port: 8000
     mountSources: true
     volumes:
       - name: m2
@@ -66,8 +73,8 @@ commands:
     actions:
       -
         type: exec
-        component: maven
-        command: "scl enable rh-maven35 'mvn fabric8:deploy -Popenshift -DskipTests'"
+        component: deployment
+        command: "mvn fabric8:deploy -Popenshift -DskipTests"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: debug

--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
@@ -31,12 +31,8 @@ components:
   -
     type: dockerimage
     alias: maven
-    # NOTE: Need EAP 7.3 RHEL 7 / JDK 8 image for Fuse support (not RHEL 8 / JDK 11)
-    # NOTE: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7 == 7.3.0, but we can use the newer 7.3.1 / XP 1.0 image (CRW-876, CRW-871)
-
-    # TODO: For Z and Power, likely need to switch at build time to an openj9-8 image, if it exists (CRW-758)
-    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk8-openshift-rhel7:1.0 when it's live (June 1?)
-    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk8-openshift-rhel7:latest
+    # might be able to use JDK 11 here but 8 is multi-arch too (x86_64, s390x, ppc64le)
+    image: registry.redhat.io/ubi8/openjdk-8:1.3
     env:
       - name: MAVEN_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
@@ -58,7 +54,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "MAVEN_OPTS='-Xmx200m' && scl enable rh-maven35 'mvn clean package'"
+        command: "MAVEN_OPTS='-Xmx200m' && mvn clean package"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: run app
@@ -66,7 +62,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "scl enable rh-maven35 'mvn spring-boot:run'"
+        command: "mvn spring-boot:run"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: deploy to OpenShift
@@ -82,7 +78,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "scl enable rh-maven35 'mvn spring-boot:run -Drun.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\"'"
+        command: "mvn spring-boot:run -Drun.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\""
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: Debug remote java application

--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
@@ -21,28 +21,21 @@ components:
     id: redhat/dependency-analytics/latest
   -
     type: dockerimage
-    mountSources: true
-    memoryLimit: 512Mi
-    volumes:
-      - name: m2
-        containerPath: /home/jboss/.m2
-    image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2'
-    alias: deployment
-  -
-    type: dockerimage
     alias: maven
-    # might be able to use JDK 11 here but 8 is multi-arch too (x86_64, s390x, ppc64le)
-    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk8-openshift-rhel7:latest
+    # image: quay.io/crw/plugin-java8-rhel8:2.2
+    image: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8:2.2
     env:
-      - name: MAVEN_OPTS
+      - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
           -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
           -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
           -Duser.home=/home/jboss"
+      - name: MAVEN_OPTS
+        value: $(JAVA_OPTS)
     memoryLimit: 768Mi
     endpoints:
-      - name: '8000'
-        port: 8000
+      - name: '8080'
+        port: 8080
     mountSources: true
     volumes:
       - name: m2
@@ -54,7 +47,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "MAVEN_OPTS='-Xmx200m' && scl enable rh-maven35 'mvn clean package'"
+        command: "MAVEN_OPTS='-Xmx200m' && mvn clean package"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: run app
@@ -62,14 +55,14 @@ commands:
       -
         type: exec
         component: maven
-        command: "scl enable rh-maven35 'mvn spring-boot:run -Drun.jvmArguments='-Dserver.port=8000''"
+        command: "mvn spring-boot:run"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: deploy to OpenShift
     actions:
       -
         type: exec
-        component: deployment
+        component: maven
         command: "mvn fabric8:deploy -Popenshift -DskipTests"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
@@ -78,7 +71,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "scl enable rh-maven35 'mvn spring-boot:run -Drun.jvmArguments=\"-Dserver.port=8000 -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\"'"
+        command: "mvn spring-boot:run -Drun.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\""
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: Debug remote java application

--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/meta.yaml
@@ -3,4 +3,4 @@ displayName: Red Hat Fuse
 description: Red Hat Fuse stack with OpenJDK 8 and Maven 3.6.3
 tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Red Hat Fuse"]
 icon: /images/type-fuse.svg
-globalMemoryLimit: 3328Mi
+globalMemoryLimit: 2816Mi

--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Red Hat Fuse
-description: Red Hat Fuse stack with OpenJDK 8 and Maven 3.6.2
+description: Red Hat Fuse stack with OpenJDK 8 and Maven 3.6.3
 tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Red Hat Fuse"]
 icon: /images/type-fuse.svg
 globalMemoryLimit: 3328Mi

--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Red Hat Fuse
-description: Red Hat Fuse stack with EAP 7.3.1, OpenJDK 1.8 and Maven 3.5.0
-tags: ["RHEL8", "Java", "OpenJDK", "Maven", "EAP", "Red Hat Fuse"]
+description: Red Hat Fuse stack with OpenJDK 8 and Maven 3.6.2
+tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Red Hat Fuse"]
 icon: /images/type-fuse.svg
 globalMemoryLimit: 3328Mi

--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Red Hat Fuse
-description: Red Hat Fuse stack with EAP 7.2.7, OpenJDK 1.8 and Maven 3.5.4
+description: Red Hat Fuse stack with EAP 7.3.1, OpenJDK 1.8 and Maven 3.5.0
 tags: ["RHEL8", "Java", "OpenJDK", "Maven", "EAP", "Red Hat Fuse"]
 icon: /images/type-fuse.svg
-globalMemoryLimit: 2816Mi
+globalMemoryLimit: 3328Mi

--- a/dependencies/che-devfile-registry/devfiles/02_java-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-maven/devfile.yaml
@@ -19,9 +19,8 @@ components:
   -
     type: dockerimage
     alias: maven
-    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
-    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
-    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
+    # image: quay.io/crw/plugin-java11-rhel8:latest
+    image: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2
     env:
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"

--- a/dependencies/che-devfile-registry/devfiles/02_java-maven/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-maven/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Java Maven
-description: Java stack with OpenJDK 8, Maven 3.5.4 and Vert.x demo application
+description: Java stack with OpenJDK 11, Maven 3.6.3 and Vert.x demo application
 tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Vert.x"]
 icon: /images/type-java.svg
 globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
@@ -15,8 +15,8 @@ components:
     type: chePlugin
   - mountSources: true
     endpoints:
-      - name: 8000-tcp
-        port: 8000
+      - name: 8080-tcp
+        port: 8080
     memoryLimit: 768Mi
     type: dockerimage
     volumes:

--- a/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
@@ -13,10 +13,18 @@ components:
   - id: redhat/dependency-analytics/latest
     # NOTE: instead of the old stack-analysis script, should be able to use the latest dependency-analysis plugin instead
     type: chePlugin
+  - type: dockerimage
+    mountSources: true
+    memoryLimit: 512Mi
+    volumes:
+      - name: m2
+        containerPath: /home/jboss/.m2
+    image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2'
+    alias: deployment
   - mountSources: true
     endpoints:
-      - name: 8080-tcp
-        port: 8080
+      - name: 8000-tcp
+        port: 8000
     memoryLimit: 768Mi
     type: dockerimage
     volumes:
@@ -24,16 +32,14 @@ components:
         containerPath: /home/jboss/.m2
     alias: maven
     # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
-    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
-    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
+    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk8-openshift-rhel8:1.0 when it's live (June 1?)
+    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk8-openshift-rhel7:latest
     env:
       - value: >-
           -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
           -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true
           -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss
-        name: JAVA_OPTS
-      - value: $(JAVA_OPTS)
         name: MAVEN_OPTS
 commands:
   - name: build
@@ -41,8 +47,8 @@ commands:
       - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec
         command: >-
-          MAVEN_OPTS="-Xmx200m" && mvn -Duser.home=${HOME} -DskipTests clean
-          install
+          MAVEN_OPTS="-Xmx200m" && scl enable rh-maven35 'mvn -Duser.home=${HOME} -DskipTests clean
+          install'
         component: maven
   - name: Debug remote java application
     actions:
@@ -55,7 +61,7 @@ commands:
                "name": "Debug (Attach) - Remote",
                "request": "attach",
                "hostName": "localhost",
-               "port": 8000
+               "port": 5005
              }]
            }
         type: vscode-launch
@@ -63,25 +69,25 @@ commands:
     actions:
       - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec
-        command: 'MAVEN_OPTS="-Xmx200m" && mvn -Duser.home=${HOME} spring-boot:run'
+        command: MAVEN_OPTS="-Xmx200m" && scl enable rh-maven35 'mvn -Duser.home=${HOME} spring-boot:run -Drun.jvmArguments='-Dserver.port=8000''
         component: maven
   - name: debug
     actions:
       - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec
         command: >-
-          mvn  -Duser.home=${HOME} spring-boot:run -Drun.jvmArguments="-Xdebug
-          -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000"
+          scl enable rh-maven35 'mvn  -Duser.home=${HOME} spring-boot:run -Drun.jvmArguments="-Dserver.port=8000 -Xdebug
+          -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005"'
         component: maven
   - name: test
     actions:
       - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec
-        command: 'MAVEN_OPTS="-Xmx200m" && mvn -Duser.home=${HOME} verify'
+        command: MAVEN_OPTS="-Xmx200m" && scl enable rh-maven35 'mvn -Duser.home=${HOME} verify'
         component: maven
   - name: deploy to OpenShift
     actions:
       - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec
         command: 'mvn fabric8:deploy -Popenshift -DskipTests'
-        component: maven
+        component: deployment

--- a/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
@@ -8,19 +8,11 @@ projects:
       type: git
       branch: master
 components:
-  - id: redhat/java11/latest
+  - id: redhat/java8/latest
     type: chePlugin
   - id: redhat/dependency-analytics/latest
     # NOTE: instead of the old stack-analysis script, should be able to use the latest dependency-analysis plugin instead
     type: chePlugin
-  - type: dockerimage
-    mountSources: true
-    memoryLimit: 512Mi
-    volumes:
-      - name: m2
-        containerPath: /home/jboss/.m2
-    image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2'
-    alias: deployment
   - mountSources: true
     endpoints:
       - name: 8000-tcp
@@ -31,15 +23,16 @@ components:
       - name: m2
         containerPath: /home/jboss/.m2
     alias: maven
-    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
-    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk8-openshift-rhel8:1.0 when it's live (June 1?)
-    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk8-openshift-rhel7:latest
+    # image: quay.io/crw/plugin-java8-rhel8:2.2
+    image: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8:2.2
     env:
       - value: >-
           -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
           -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4
           -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true
           -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss
+        name: JAVA_OPTS
+      - value: $(JAVA_OPTS)
         name: MAVEN_OPTS
 commands:
   - name: build
@@ -47,8 +40,8 @@ commands:
       - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec
         command: >-
-          MAVEN_OPTS="-Xmx200m" && scl enable rh-maven35 'mvn -Duser.home=${HOME} -DskipTests clean
-          install'
+          MAVEN_OPTS="-Xmx200m" && mvn -Duser.home=${HOME} -DskipTests clean
+          install
         component: maven
   - name: Debug remote java application
     actions:
@@ -69,25 +62,25 @@ commands:
     actions:
       - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec
-        command: MAVEN_OPTS="-Xmx200m" && scl enable rh-maven35 'mvn -Duser.home=${HOME} spring-boot:run -Drun.jvmArguments='-Dserver.port=8000''
+        command: MAVEN_OPTS="-Xmx200m" && mvn -Duser.home=${HOME} spring-boot:run
         component: maven
   - name: debug
     actions:
       - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec
         command: >-
-          scl enable rh-maven35 'mvn  -Duser.home=${HOME} spring-boot:run -Drun.jvmArguments="-Dserver.port=8000 -Xdebug
-          -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005"'
+         mvn  -Duser.home=${HOME} spring-boot:run -Drun.jvmArguments="-Xdebug
+          -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005"
         component: maven
   - name: test
     actions:
       - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec
-        command: MAVEN_OPTS="-Xmx200m" && scl enable rh-maven35 'mvn -Duser.home=${HOME} verify'
+        command: MAVEN_OPTS="-Xmx200m" && mvn -Duser.home=${HOME} verify
         component: maven
   - name: deploy to OpenShift
     actions:
       - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec
         command: 'mvn fabric8:deploy -Popenshift -DskipTests'
-        component: deployment
+        component: maven

--- a/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Java Spring Boot
-description: Java stack with OpenJDK 8, Maven 3.5.4 and Spring Boot Petclinic demo application
+description: Java stack with OpenJDK 8, Maven 3.6.2 and Spring Boot Petclinic demo application
 tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Spring Boot", "EAP"]
 icon: /images/type-snowdrop.svg
 globalMemoryLimit: 3072Mi

--- a/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Java Spring Boot
-description: Java stack with OpenJDK 8, Maven 3.6.2 and Spring Boot Petclinic demo application
-tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Spring Boot", "EAP"]
+description: Java stack with OpenJDK 8, Maven 3.6.3 and Spring Boot Petclinic demo application
+tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Spring Boot"]
 icon: /images/type-snowdrop.svg
 globalMemoryLimit: 3072Mi

--- a/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/devfile.yaml
@@ -23,9 +23,8 @@ components:
       - name: m2
         containerPath: /home/jboss/.m2
     alias: maven
-    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
-    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
-    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
+    # image: quay.io/crw/plugin-java11-rhel8:latest
+    image: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2
     env:
       - value: >-
           -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10

--- a/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Java Vert.x
-description: Java stack with OpenJDK 8, Maven 3.5.4 and Vert.x demo application
-tags: ["RHEL8", "Java", "OpenJDK", "Maven", "EAP", "Vertx"]
+description: Java stack with OpenJDK 11, Maven 3.6.3 and Vert.x demo application
+tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Vertx"]
 icon: /images/type-vertx.svg
 globalMemoryLimit: 2674Mi


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Updates java-based stacks with new java images

- Fuse: plugin-java8-rhel8
- thorntail: plugin-java8-rhel8
- java-maven: plugin-java11-rhel8
- springboot: plugin-java8-rhel8
- vertx: plugin-java11-rhel8
- java-eap-maven: eap73-openjdk11-openshift-rhel8  **(run command doesn't work)**
 
### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-871