### PR TITLE
Switch e2e selenium tests to 7.15.0-SNAPSHOT Che version

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -28,7 +28,7 @@
         <module>codeready-test-performance</module>
     </modules>
     <properties>
-        <che.version>7.14.0-SNAPSHOT</che.version>
+        <che.version>7.15.0-SNAPSHOT</che.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -27,6 +27,9 @@
         <module>codeready-test-e2e</module>
         <module>codeready-test-performance</module>
     </modules>
+    <properties>
+        <che.version>7.14.0-SNAPSHOT</che.version>
+    </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
### What does this PR do?
It switches CRW java selenium tests to use upstream Eclipse Che java selenium tests from master branch.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-940