### PR TITLE
CRW-932 EAP based devfiles to use released EAP 7.3/JDK11; other Java devfiles to use OpenJDK8

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/devfile.yaml
@@ -19,9 +19,12 @@ components:
   -
     type: dockerimage
     alias: maven
-    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
-    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
-    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
+    # NOTE: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
+    # NOTE: can test pre-release image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
+    # NOTE: there's also a JDK8 version at registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:7.3.0 ...
+    #       BUT the JDK8/RHEL7 image requires using "scl enable rh-maven35 'mvn -version'" to run maven, so devfile will need adjustment.
+    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live
+    image: registry.redhat.io/jboss-eap-7/eap73-openjdk11-openshift-rhel8:7.3.0
     env:
       - name: MAVEN_OPTS
         value: "-Xmx200m -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"

--- a/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java-eap-maven/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Java EAP Maven
-description: Java stack with EAP 7.2.7, OpenJDK 1.8 and Maven 3.5.4
+description: Java stack with EAP 7.3, OpenJDK 11 and Maven 3.5
 tags: ["RHEL8", "Java", "OpenJDK", "Maven", "EAP"]
 icon: /images/type-jboss.svg
 globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/01_java-eap-thorntail/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/01_java-eap-thorntail/devfile.yaml
@@ -19,9 +19,12 @@ components:
   -
     type: dockerimage
     alias: maven
-    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
-    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
-    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
+    # NOTE: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
+    # NOTE: can test pre-release image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
+    # NOTE: there's also a JDK8 version at registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:7.3.0 ...
+    #       BUT the JDK8/RHEL7 image requires using "scl enable rh-maven35 'mvn -version'" to run maven, so devfile will need adjustment.
+    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live
+    image: registry.redhat.io/jboss-eap-7/eap73-openjdk11-openshift-rhel8:7.3.0
     env:
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"

--- a/dependencies/che-devfile-registry/devfiles/01_java-eap-thorntail/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/01_java-eap-thorntail/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Java EAP Thorntail
-description: Quickstart to expose a REST Greeting endpoint using Thorntail with EAP 7.2.7, OpenJDK 1.8 and Maven 3.5.4
+description: Quickstart to expose a REST Greeting endpoint using Thorntail with EAP 7.3, OpenJDK 11 and Maven 3.5
 tags: ["RHEL8", "Java", "OpenJDK", "Maven", "EAP", "Thorntail"]
 icon: /images/type-thorntail.svg
 globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
@@ -22,12 +22,8 @@ components:
   -
     type: dockerimage
     alias: maven
-    # NOTE: Need EAP 7.3 RHEL 7 / JDK 8 image for Fuse support (not RHEL 8 / JDK 11)
-    # NOTE: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7 == 7.3.0, but we can use the newer 7.3.1 / XP 1.0 image (CRW-876, CRW-871)
-
-    # TODO: For Z and Power, likely need to switch at build time to an openj9-8 image, if it exists (CRW-758)
-    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk8-openshift-rhel7:1.0 when it's live (June 1?)
-    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk8-openshift-rhel7:latest
+    # might be able to use JDK 11 here but 8 is multi-arch too (x86_64, s390x, ppc64le)
+    image: registry.redhat.io/ubi8/openjdk-8:1.3
     env:
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
@@ -51,7 +47,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "MAVEN_OPTS='-Xmx200m' && scl enable rh-maven35 'mvn clean package'"
+        command: "MAVEN_OPTS='-Xmx200m' && mvn clean package"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: run app
@@ -59,7 +55,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "scl enable rh-maven35 'mvn spring-boot:run'"
+        command: "mvn spring-boot:run"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: deploy to OpenShift
@@ -67,7 +63,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "scl enable rh-maven35 'mvn fabric8:deploy -Popenshift -DskipTests'"
+        command: "mvn fabric8:deploy -Popenshift -DskipTests"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: debug
@@ -75,7 +71,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "scl enable rh-maven35 'mvn spring-boot:run -Drun.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\"'"
+        command: "mvn spring-boot:run -Drun.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\""
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -
     name: Debug remote java application

--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
@@ -21,6 +21,15 @@ components:
     id: redhat/dependency-analytics/latest
   -
     type: dockerimage
+    mountSources: true
+    memoryLimit: 512Mi
+    volumes:
+      - name: m2
+        containerPath: /home/jboss/.m2
+    image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2'
+    alias: deployment
+  -
+    type: dockerimage
     alias: maven
     # might be able to use JDK 11 here but 8 is multi-arch too (x86_64, s390x, ppc64le)
     image: registry.redhat.io/ubi8/openjdk-8:1.3
@@ -62,7 +71,7 @@ commands:
     actions:
       -
         type: exec
-        component: maven
+        component: deployment
         command: "mvn fabric8:deploy -Popenshift -DskipTests"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -

--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
@@ -21,18 +21,8 @@ components:
     id: redhat/dependency-analytics/latest
   -
     type: dockerimage
-    mountSources: true
-    memoryLimit: 512Mi
-    volumes:
-      - name: m2
-        containerPath: /home/jboss/.m2
-    image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2'
-    alias: deployment
-  -
-    type: dockerimage
     alias: maven
-    # might be able to use JDK 11 here but 8 is multi-arch too (x86_64, s390x, ppc64le)
-    image: registry.redhat.io/ubi8/openjdk-8:1.3
+    image: 'registry.redhat.io/codeready-workspaces/plugin-java8-rhel8:2.2'
     env:
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
@@ -71,7 +61,7 @@ commands:
     actions:
       -
         type: exec
-        component: deployment
+        component: maven
         command: "mvn fabric8:deploy -Popenshift -DskipTests"
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   -

--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Red Hat Fuse
-description: Red Hat Fuse stack with EAP 7.2.7, OpenJDK 1.8 and Maven 3.5.4
-tags: ["RHEL8", "Java", "OpenJDK", "Maven", "EAP", "Red Hat Fuse"]
+description: Red Hat Fuse stack with OpenJDK 8 and Maven 3.6.2
+tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Red Hat Fuse"]
 icon: /images/type-fuse.svg
 globalMemoryLimit: 2816Mi

--- a/dependencies/che-devfile-registry/devfiles/02_java-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-maven/devfile.yaml
@@ -18,17 +18,8 @@ components:
     id: redhat/dependency-analytics/latest
   -
     type: dockerimage
-    mountSources: true
-    memoryLimit: 512Mi
-    volumes:
-      - name: m2
-        containerPath: /home/jboss/.m2
-    image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2'
-    alias: deployment
-  -
-    type: dockerimage
     alias: maven
-    image: registry.redhat.io/ubi8/openjdk-8:1.3
+    image: 'registry.redhat.io/codeready-workspaces/plugin-java8-rhel8:2.2'
     env:
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"
@@ -79,7 +70,7 @@ commands:
       - workdir: '${CHE_PROJECTS_ROOT}/vertx-health-checks-example-redhat'
         type: exec
         command: "mvn fabric8:deploy -Popenshift -DskipTests -Dvertx.disableDnsResolver=true"
-        component: deployment
+        component: maven
   -
     name: Attach remote debugger
     actions:

--- a/dependencies/che-devfile-registry/devfiles/02_java-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-maven/devfile.yaml
@@ -19,9 +19,7 @@ components:
   -
     type: dockerimage
     alias: maven
-    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
-    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
-    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
+    image: registry.redhat.io/ubi8/openjdk-8:1.3
     env:
       - name: JAVA_OPTS
         value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss"

--- a/dependencies/che-devfile-registry/devfiles/02_java-maven/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-maven/devfile.yaml
@@ -18,6 +18,15 @@ components:
     id: redhat/dependency-analytics/latest
   -
     type: dockerimage
+    mountSources: true
+    memoryLimit: 512Mi
+    volumes:
+      - name: m2
+        containerPath: /home/jboss/.m2
+    image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2'
+    alias: deployment
+  -
+    type: dockerimage
     alias: maven
     image: registry.redhat.io/ubi8/openjdk-8:1.3
     env:
@@ -70,7 +79,7 @@ commands:
       - workdir: '${CHE_PROJECTS_ROOT}/vertx-health-checks-example-redhat'
         type: exec
         command: "mvn fabric8:deploy -Popenshift -DskipTests -Dvertx.disableDnsResolver=true"
-        component: maven
+        component: deployment
   -
     name: Attach remote debugger
     actions:

--- a/dependencies/che-devfile-registry/devfiles/02_java-maven/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-maven/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Java Maven
-description: Java stack with OpenJDK 8, Maven 3.5.4 and Vert.x demo application
+description: Java stack with OpenJDK 8, Maven 3.6.2 and Vert.x demo application
 tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Vert.x"]
 icon: /images/type-java.svg
 globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
@@ -13,6 +13,15 @@ components:
   - id: redhat/dependency-analytics/latest
     # NOTE: instead of the old stack-analysis script, should be able to use the latest dependency-analysis plugin instead
     type: chePlugin
+  -
+    type: dockerimage
+    mountSources: true
+    memoryLimit: 512Mi
+    volumes:
+      - name: m2
+        containerPath: /home/jboss/.m2
+    image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2'
+    alias: deployment
   - mountSources: true
     endpoints:
       - name: 8080-tcp
@@ -82,4 +91,4 @@ commands:
       - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec
         command: 'mvn fabric8:deploy -Popenshift -DskipTests'
-        component: maven
+        component: deployment

--- a/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
@@ -13,15 +13,6 @@ components:
   - id: redhat/dependency-analytics/latest
     # NOTE: instead of the old stack-analysis script, should be able to use the latest dependency-analysis plugin instead
     type: chePlugin
-  -
-    type: dockerimage
-    mountSources: true
-    memoryLimit: 512Mi
-    volumes:
-      - name: m2
-        containerPath: /home/jboss/.m2
-    image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2'
-    alias: deployment
   - mountSources: true
     endpoints:
       - name: 8080-tcp
@@ -32,7 +23,7 @@ components:
       - name: m2
         containerPath: /home/jboss/.m2
     alias: maven
-    image: registry.redhat.io/ubi8/openjdk-8:1.3
+    image: 'registry.redhat.io/codeready-workspaces/plugin-java8-rhel8:2.2'
     env:
       - value: >-
           -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
@@ -91,4 +82,4 @@ commands:
       - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec
         command: 'mvn fabric8:deploy -Popenshift -DskipTests'
-        component: deployment
+        component: maven

--- a/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
@@ -23,9 +23,7 @@ components:
       - name: m2
         containerPath: /home/jboss/.m2
     alias: maven
-    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
-    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
-    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
+    image: registry.redhat.io/ubi8/openjdk-8:1.3
     env:
       - value: >-
           -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10

--- a/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Java Spring Boot
-description: Java stack with OpenJDK 8, Maven 3.5.4 and Spring Boot Petclinic demo application
-tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Spring Boot", "EAP"]
+description: Java stack with OpenJDK 8, Maven 3.6.2 and Spring Boot Petclinic demo application
+tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Spring Boot"]
 icon: /images/type-snowdrop.svg
 globalMemoryLimit: 3072Mi

--- a/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/devfile.yaml
@@ -13,6 +13,15 @@ components:
   - id: redhat/dependency-analytics/latest
     # NOTE: instead of the old stack-analysis script, should be able to use the latest dependency-analysis plugin instead
     type: chePlugin
+  -
+    type: dockerimage
+    mountSources: true
+    memoryLimit: 512Mi
+    volumes:
+      - name: m2
+        containerPath: /home/jboss/.m2
+    image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2'
+    alias: deployment
   - mountSources: true
     endpoints:
       - name: 8080-tcp
@@ -86,4 +95,4 @@ commands:
         command: >-
           MAVEN_OPTS="-Xmx200m" &&  mvn fabric8:deploy -Popenshift -DskipTests
           -Dvertx.disableDnsResolver=true
-        component: maven
+        component: deployment

--- a/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/devfile.yaml
@@ -13,15 +13,6 @@ components:
   - id: redhat/dependency-analytics/latest
     # NOTE: instead of the old stack-analysis script, should be able to use the latest dependency-analysis plugin instead
     type: chePlugin
-  -
-    type: dockerimage
-    mountSources: true
-    memoryLimit: 512Mi
-    volumes:
-      - name: m2
-        containerPath: /home/jboss/.m2
-    image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.2'
-    alias: deployment
   - mountSources: true
     endpoints:
       - name: 8080-tcp
@@ -32,7 +23,7 @@ components:
       - name: m2
         containerPath: /home/jboss/.m2
     alias: maven
-    image: registry.redhat.io/ubi8/openjdk-8:1.3
+    image: 'registry.redhat.io/codeready-workspaces/plugin-java8-rhel8:2.2'
     env:
       - value: >-
           -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
@@ -95,4 +86,4 @@ commands:
         command: >-
           MAVEN_OPTS="-Xmx200m" &&  mvn fabric8:deploy -Popenshift -DskipTests
           -Dvertx.disableDnsResolver=true
-        component: deployment
+        component: maven

--- a/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/devfile.yaml
@@ -23,9 +23,7 @@ components:
       - name: m2
         containerPath: /home/jboss/.m2
     alias: maven
-    # TODO: For Z and Power, likely need to switch at build time to an openj9-11 image, if it exists (CRW-758)
-    # TODO: switch to registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0 when it's live (June 1?)
-    image: registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8:latest
+    image: registry.redhat.io/ubi8/openjdk-8:1.3
     env:
       - value: >-
           -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10

--- a/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_vertx-http-booster/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: Java Vert.x
-description: Java stack with OpenJDK 8, Maven 3.5.4 and Vert.x demo application
-tags: ["RHEL8", "Java", "OpenJDK", "Maven", "EAP", "Vertx"]
+description: Java stack with OpenJDK 8, Maven 3.6.2 and Vert.x demo application
+tags: ["RHEL8", "Java", "OpenJDK", "Maven", "Vertx"]
 icon: /images/type-vertx.svg
 globalMemoryLimit: 2674Mi


### PR DESCRIPTION
CRW-932 switch 2 EAP based devfiles to use EAP 7.3 + JDK 11 released image (rather than internal one)

Change-Id: Iddd845cb5b13b00940cf86659e2b9aba6fead52b
Signed-off-by: nickboldt <nboldt@redhat.com>