### PR TITLE
Fix typo in a command to fetch the current version (required for Atlascode extension for VS Code )

### DIFF
--- a/dependencies/che-plugin-registry/vsix.Jenkinsfile
+++ b/dependencies/che-plugin-registry/vsix.Jenkinsfile
@@ -127,7 +127,7 @@ def buildAtlascode(extensionFolder) {
     sh "cd ${extensionFolder}"
 
     // get exactly Branch name
-    def version = sh script: "git symbolic-ref -q --short HEAD || git describe --tags --exact-match)", returnStdout: true
+    def version = sh script: "git symbolic-ref -q --short HEAD || git describe --tags --exact-match", returnStdout: true
 
     sh """\
     npm install -g vsce && \


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Fixes typo in a command line, fetching the current version name
A part of this PR https://github.com/redhat-developer/codeready-workspaces/pull/316
