### PR TITLE
🚧 Don't hard-code docs version related to converting CRW 1.2 workspace 2.0

### DIFF
--- a/assembly/branding/product.json.template
+++ b/assembly/branding/product.json.template
@@ -32,7 +32,7 @@
     "workspace" : "@@crw.docs.baseurl@@/html-single/end-user_guide/index#workspaces-overview_crw",
     "factory" : "@@crw.docs.baseurl@@/html-single/end-user_guide/index#overriding-devfile-values-using-factory-parameters_configuring-a-workspace-using-a-devfile",
     "organization": "@@crw.docs.baseurl@@/html-single/administration_guide/index#managing-users_crw",
-    "converting": "https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/2.0/html-single/end-user_guide/index#converting-a-codeready-workspaces-1.2-workspace-to-a-codeready-workspaces-2.0-devfile",
+    "converting": "@@crw.docs.baseurl@@/html-single/end-user_guide/index#converting-a-codeready-workspaces-1.2-workspace-to-a-codeready-workspaces-2.0-devfile",
     "certificate": "@@crw.docs.baseurl@@/html-single/installation_guide/index#deploying-codeready-workspaces-with-support-for-git-repositories-with-self-signed-certificates_advanced-configuration-options",
     "general": "@@crw.docs.baseurl@@/"
   }


### PR DESCRIPTION
### What does this PR do?
I occasionally figured out that we have such a link which is hard-coded to a specific CRW version which I suppose is the wrong thing to do since recently we have updated the corresponding article in upstream https://github.com/eclipse/che-docs/pull/1358 which is going to appear in CRW 2.2 Docs.

With this PR I just wanted to raise that outdated documentation referencing and it's just suggestions I'm not sure about like if it's the right link we'll have working in the end - @rkratky @nickboldt feel free to update the PR

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17218
