### PR TITLE
CRW-994 clean up typos, interactive script...

### DIFF
--- a/dependencies/che-plugin-registry/Jenkinsfile
+++ b/dependencies/che-plugin-registry/Jenkinsfile
@@ -90,6 +90,19 @@ cd ${WORKSPACE}/sources
   git remote set-url origin https://\$GITHUB_TOKEN:x-oauth-basic@github.com/''' + SOURCE_REPO + '''.git
   git remote -v
 
+  # Check if che-machine-exec and che-theia plugins are current in upstream repo and if not, add them
+  pushd ${SOURCEDIR} >/dev/null
+  LATEST_CHE_VERSION=$(cat ${WORKSPACE}/sources/pom.xml | grep -E "<che.version>" | sed -r -e "s#.+<che.version>(.+)</che.version>#\1#")
+  LATEST_MACHINE_EXEC=$(cat v3/plugins/eclipse/che-machine-exec-plugin/latest.txt)
+  LATEST_THEIA=$(cat v3/plugins/eclipse/che-theia/latest.txt)
+  if [[ ! -d "v3/plugins/eclipse/che-machine-exec-plugin" ]] || [[ ! -d "v3/plugins/eclipse/che-theia" ]] || \
+    [[ ${LATEST_CHE_VERSION} != ${LATEST_MACHINE_EXEC} ]] || [[ ${LATEST_CHE_VERSION} != ${LATEST_THEIA} ]]; then
+    pushd ${WORKSPACE}/dependencies/che-plugin-registry/ >/dev/null
+    ./build/scripts/add_che_plugins.sh ${LATEST_CHE_VERSION}
+    popd >/dev/null
+  fi
+  popd >/dev/null
+
   OLD_SHA=$(git rev-parse HEAD) # echo ${OLD_SHA:0:8}
   pushd ${SOURCEDOCKERFILE%/*} >/dev/null
     /tmp/updateBaseImages.sh -b ''' + SOURCE_BRANCH + ''' -f ${SOURCEDOCKERFILE##*/} # just pass in rhel.Dockerfile
@@ -106,28 +119,6 @@ cd ${WORKSPACE}/target
   git config user.email crw-build@REDHAT.COM
   git config user.name "CRW Build"
   git config --global push.default matching
-
-LATEST_CHE_VERSION=`(curl -sSLo - https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/pom.xml | grep -E "<che.version>" | sed -r -e "s#.+<che.version>(.+)</che.version>#\1#")`
-
-# To check che-machine-exec-plugin and che-theia installed or not
-if [ ! -d "v3/plugins/eclipse/che-machine-exec-plugin" ] && [ ! -d "v3/plugins/eclipse/che-theia" ]
-then
-	sh ${WORKSPACE}/dependencies/che-plugin-registry/build/scripts/add_che_plugins.sh ${LATEST_CHE_VERSION}
-fi
-
-# To check installed che-machine-exec-plugin and che-theia version is latest or not
-INSTALLED_CHE_MACHINE_EXEC_PLUGIN_VERSION=`cat v3/plugins/eclipse/che-machine-exec-plugin/latest.txt`
-INSTALLED_CHE_THEIA_VERSION=`cat v3/plugins/eclipse/che-theia/latest.txt`
-
-if [ ${LATEST_CHE_VERSION} == ${INSTALLED_CHE_MACHINE_EXEC_PLUGIN_VERSION} ] && [ ${LATEST_CHE_VERSION} == ${INSTALLED_CHE_THEIA_VERSION} ]
-then
-        echo "Che is installed with latest version : ${LATEST_CHE_VERSION}"
-else
-	sh ${WORKSPACE}/dependencies/che-plugin-registry/build/scripts/add_che_plugins.sh ${LATEST_CHE_VERSION}
-fi
-
-cd ..
-
 '''
       sh BOOTSTRAP
 

--- a/dependencies/che-plugin-registry/build/scripts/add_che_plugins.sh
+++ b/dependencies/che-plugin-registry/build/scripts/add_che_plugins.sh
@@ -24,17 +24,6 @@ if [[ ! ${VERSION} ]]; then
   exit 1
 fi
 
-# check given che-machine-exec-plugin and che-theia versions is already installed or not, to avaoid redundent commits
-if [ -d "v3/plugins/eclipse/che-machine-exec-plugin/${VERSION}" ] && [ -d "v3/plugins/eclipse/che-theia/${VERSION}" ]
-then
-  echo "${VERSION} che version is already installed."
-  read -p "Do you want to install same version again [y/n] : " answer
-  if [ "${answer}" == "n" ] || [ "${answer}" == "N" ] || [ "${answer}" == "no" ] || [ "${answer}" == "No" ]
-  then
-  exit 1
-  fi
-fi
-	
 # generate new meta.yaml files for the plugins, and update the latest.txt files
 createNewPlugins () {
   newVERSION=$1
@@ -54,16 +43,21 @@ createNewPlugins () {
   done
 }
 
-# change VERSION file
-echo "${VERSION}" > VERSION
-# add new plugins + update latest.txt files
-createNewPlugins "${VERSION}"
+# check if che-machine-exec-plugin and che-theia version is already installed to avoid redundent commits
+if [[ -d "v3/plugins/eclipse/che-machine-exec-plugin/${VERSION}" ]] && [[ -d "v3/plugins/eclipse/che-theia/${VERSION}" ]]; then
+  echo "[WARNING] che-theia and che-machine-exec plugins ${VERSION} already in registry - nothing to do."
+else
+  # change VERSION file
+  echo "${VERSION}" > VERSION
+  # add new plugins + update latest.txt files
+  createNewPlugins "${VERSION}"
 
-# commit change into branch
-if [[ ${NOCOMMIT} -eq 0 ]]; then
-  COMMIT_MSG="[release] Add che-theia and che-machine-exec plugins ${VERSION} in ${BRANCH}"
-  git add v3/plugins/eclipse/ || true
-  git commit -s -m "${COMMIT_MSG}" VERSION v3/plugins/eclipse/
-  git pull origin "${BRANCH}"
-  git push origin "${BRANCH}"
+  # commit change into branch
+  if [[ ${NOCOMMIT} -eq 0 ]]; then
+    COMMIT_MSG="[release] Add che-theia and che-machine-exec plugins ${VERSION} in ${BRANCH}"
+    git add v3/plugins/eclipse/ || true
+    git commit -s -m "${COMMIT_MSG}" VERSION v3/plugins/eclipse/
+    git pull origin "${BRANCH}"
+    git push origin "${BRANCH}"
+  fi
 fi


### PR DESCRIPTION
CRW-994 clean up typos, interactive script option (doesn't work in Jenkins) and move logic so that it's applied in MIDSTREAM GH repo instead of only in DOWNSTREAM pkgs.devel repo

Change-Id: I99f48ef977bdddf36ef9c5ba715054c20c8bcd10
Signed-off-by: nickboldt <nboldt@redhat.com>