### PR TITLE
bump to new GIT_BRANCH = crw-2.4-rhel-8; use...

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,13 +6,13 @@
 // branchToBuildDev = refs/tags/19
 // branchToBuildParent = refs/tags/7.15.0
 // branchToBuildChe = refs/tags/7.16.x
-// branchToBuildCRW = master
+// branchToBuildCRW = crw-2.4-rhel-8
 // BUILDINFO = ${JOB_NAME}/${BUILD_NUMBER}
 // MVN_EXTRA_FLAGS = extra flags, such as to disable a module -pl '!org.eclipse.che.selenium:che-selenium-test'
 // SCRATCH = true (don't push to Quay) or false (do push to Quay)
 
 def DWNSTM_REPO = "containers/codeready-workspaces" // dist-git repo to use as target for everything
-def DWNSTM_BRANCH = "crw-2.2-rhel-8" // target branch in dist-git repo, eg., crw-2.2-rhel-8
+def DWNSTM_BRANCH = "crw-2.4-rhel-8" // target branch in dist-git repo, eg., crw-2.4-rhel-8
 
 def installNPM(){
 	def yarnVersion="1.21.0"
@@ -266,7 +266,7 @@ timeout(240) {
 		klist # verify working
 
 		# REQUIRE: skopeo
-		curl -L -s -S https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/product/updateBaseImages.sh -o /tmp/updateBaseImages.sh
+		curl -L -s -S https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + branchToBuildCRW + '''/product/updateBaseImages.sh -o /tmp/updateBaseImages.sh
 		chmod +x /tmp/updateBaseImages.sh
 
   		git checkout --track origin/''' + branchToBuildCRW + ''' || true
@@ -284,7 +284,7 @@ timeout(240) {
 		# Check if che-machine-exec and che-theia plugins are current in upstream repo and if not, add them
 		# NOTE: we want the version of che in the pom, not the value of che computed for the dashboard (che.version override)
 		pushd dependencies/che-plugin-registry >/dev/null
-			./build/scripts/add_che_plugins.sh $(cat ${WORKSPACE}/''' + CRW_path + '''/pom.xml | grep -E "<che.version>" | sed -r -e "s#.+<che.version>(.+)</che.version>#\\1#")
+			./build/scripts/add_che_plugins.sh -b ''' + branchToBuildCRW + ''' $(cat ${WORKSPACE}/''' + CRW_path + '''/pom.xml | grep -E "<che.version>" | sed -r -e "s#.+<che.version>(.+)</che.version>#\\1#")
 		popd >/dev/null
 
 		# fetch sources to be updated
@@ -323,8 +323,7 @@ COPY assembly/codeready-workspaces-assembly-main/target/codeready-workspaces-ass
 RUN tar xzf /tmp/codeready-workspaces-assembly-main.tar.gz --transform="s#.*codeready-workspaces-assembly-main/*##" -C /home/user/codeready \\&\\& rm -f /tmp/codeready-workspaces-assembly-main.tar.gz\\
 @g'
 
-		# TODO should this be a branch instead of just master?
-		CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/VERSION`
+		CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + branchToBuildCRW + '''/dependencies/VERSION`
 		# apply patches to downstream version
 		cp ${WORKSPACE}/''' + CRW_path + '''/Dockerfile ${WORKSPACE}/targetdwn/Dockerfile
 		sed -i ${WORKSPACE}/targetdwn/Dockerfile \
@@ -486,7 +485,7 @@ timeout(120) {
 				[
 				$class: 'StringParameterValue',
 				name: 'GIT_BRANCH',
-				value: "crw-2.2-rhel-8",
+				value: "crw-2.4-rhel-8",
 				],
 				[
 				$class: 'StringParameterValue',

--- a/dependencies/che-devfile-registry/Jenkinsfile
+++ b/dependencies/che-devfile-registry/Jenkinsfile
@@ -2,13 +2,13 @@
 
 // PARAMETERS for this pipeline:
 // def FORCE_BUILD = "false"
-// def SOURCE_BRANCH = "master" // 7.3.x or 7.7.x :: branch of source repo from which to find and sync commits to pkgs.devel repo
+// def SOURCE_BRANCH = "crw-2.4-rhel-8" // branch of GH and pkgs.devel repos to sync commits
 
 // TODO source from eclipse/che-devfile-registry too
 
 def SOURCE_REPO = "redhat-developer/codeready-workspaces" //source repo from which to find and sync commits to pkgs.devel repo
 def GIT_PATH = "containers/codeready-workspaces-devfileregistry" // dist-git repo to use as target
-def GIT_BRANCH = "crw-2.2-rhel-8" // target branch in dist-git repo, eg., crw-2.2-rhel-8
+def GIT_BRANCH = "crw-2.4-rhel-8" // target branch in dist-git repo, eg., crw-2.4-rhel-8
 def SCRATCH = "false"
 def PUSH_TO_QUAY = "true"
 def QUAY_PROJECT = "devfileregistry" // also used for the Brew dockerfile params
@@ -75,7 +75,7 @@ if [[ -f ${SOURCEDIR}/build/dockerfiles/rhel.Dockerfile ]]; then
 fi
 
 # REQUIRE: skopeo
-curl -L -s -S https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/product/updateBaseImages.sh -o /tmp/updateBaseImages.sh
+curl -L -s -S https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + SOURCE_BRANCH + '''/product/updateBaseImages.sh -o /tmp/updateBaseImages.sh
 chmod +x /tmp/updateBaseImages.sh
 cd ${WORKSPACE}/sources
   git checkout --track origin/''' + SOURCE_BRANCH + ''' || true
@@ -135,8 +135,7 @@ done
 
 cp -f ${SOURCEDOCKERFILE} ${WORKSPACE}/target/Dockerfile
 
-# TODO should this be a branch instead of just master?
-CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/VERSION`
+CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + SOURCE_BRANCH + '''/dependencies/VERSION`
 # apply patches to transform CRW upstream to pkgs.devel version
 sed -i ${WORKSPACE}/target/Dockerfile --regexp-extended \
   `# Replace image used for registry with rhel8/httpd-24` \
@@ -311,7 +310,7 @@ cause=${QUAY_REPO_PATH}+respin+by+${BUILD_TAG}&\
 GIT_BRANCH=''' + GIT_BRANCH + '''&\
 GIT_PATHs=containers/codeready-workspaces-${QRP}&\
 QUAY_REBUILD_PATH=${QUAY_REPO_PATH}&\
-JOB_BRANCH=master&\
+JOB_BRANCH=${CRW_VERSION}&\
 FORCE_BUILD=true&\
 SCRATCH=''' + SCRATCH + '''"
   done

--- a/dependencies/che-jwtproxy/Jenkinsfile
+++ b/dependencies/che-jwtproxy/Jenkinsfile
@@ -2,12 +2,12 @@
 
 // PARAMETERS for this pipeline:
 // def FORCE_BUILD = "false"
-// def SOURCE_BRANCH = "master" // branch of source repo from which to find and sync commits to pkgs.devel repo
+// def SOURCE_BRANCH = "7.18.x" // branch of GH and pkgs.devel repos to sync commits
 
 def SOURCE_REPO = "eclipse/che-jwtproxy" //source repo from which to find and sync commits to pkgs.devel repo
 def GIT_PATH = "containers/codeready-workspaces-jwtproxy" // dist-git repo to use as target
 
-def GIT_BRANCH = "crw-2.2-rhel-8" // target branch in dist-git repo, eg., crw-2.2-rhel-8
+def GIT_BRANCH = "crw-2.4-rhel-8" // target branch in dist-git repo, eg., crw-2.4-rhel-8
 def SCRATCH = "false"
 def PUSH_TO_QUAY = "true"
 def QUAY_PROJECT = "jwtproxy" // also used for the Brew dockerfile params
@@ -69,7 +69,7 @@ hasChanged=0
 SOURCEDOCKERFILE=${WORKSPACE}/sources/build/dockerfiles/rhel.Dockerfile
 
 # REQUIRE: skopeo
-curl -L -s -S https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/product/updateBaseImages.sh -o /tmp/updateBaseImages.sh
+curl -L -s -S https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + GIT_BRANCH + '''/product/updateBaseImages.sh -o /tmp/updateBaseImages.sh
 chmod +x /tmp/updateBaseImages.sh
 # don't bother to check/update if we're using a tag instead of a branch
 if [[ "''' + SOURCE_BRANCH + '''" != "refs/tags/"* ]]; then
@@ -125,8 +125,7 @@ done
 
 cp -f ${SOURCEDOCKERFILE} ${WORKSPACE}/target/Dockerfile
 
-# TODO should this be a branch instead of just master?
-CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/VERSION`
+CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + GIT_BRANCH + '''/dependencies/VERSION`
 #apply patches
 sed -i ${WORKSPACE}/target/Dockerfile \
   -e "s@^FROM \\(registry.access.redhat.com/devtools/.\\+\\)@# FROM \\1@g" \
@@ -191,7 +190,7 @@ cause=${QUAY_REPO_PATH}+respin+by+${BUILD_TAG}&\
 GIT_BRANCH=''' + GIT_BRANCH + '''&\
 GIT_PATHs=containers/codeready-workspaces-${QRP}&\
 QUAY_REPO_PATHs=${QUAY_REPO_PATH}&\
-JOB_BRANCH=master&\
+JOB_BRANCH=${CRW_VERSION}&\
 FORCE_BUILD=true&\
 SCRATCH=''' + SCRATCH + '''"
   done

--- a/dependencies/che-machine-exec/Jenkinsfile
+++ b/dependencies/che-machine-exec/Jenkinsfile
@@ -2,12 +2,12 @@
 
 // PARAMETERS for this pipeline:
 // def FORCE_BUILD = "false"
-// def SOURCE_BRANCH = "7.9.x" // branch of source repo from which to find and sync commits to pkgs.devel repo
+// def SOURCE_BRANCH = "7.18.x" // branch of GH and pkgs.devel repos to sync commits
 
 def SOURCE_REPO = "eclipse/che-machine-exec" //source repo from which to find and sync commits to pkgs.devel repo
 def GIT_PATH = "containers/codeready-workspaces-machineexec" // dist-git repo to use as target
 
-def GIT_BRANCH = "crw-2.2-rhel-8" // target branch in dist-git repo, eg., crw-2.2-rhel-8
+def GIT_BRANCH = "crw-2.4-rhel-8" // target branch in dist-git repo, eg., crw-2.4-rhel-8
 def SCRATCH = "false"
 def PUSH_TO_QUAY = "true"
 def QUAY_PROJECT = "machineexec" // also used for the Brew dockerfile params
@@ -69,7 +69,7 @@ hasChanged=0
 SOURCEDOCKERFILE=${WORKSPACE}/sources/build/dockerfiles/rhel.Dockerfile
 
 # REQUIRE: skopeo
-curl -L -s -S https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/product/updateBaseImages.sh -o /tmp/updateBaseImages.sh
+curl -L -s -S https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + GIT_BRANCH + '''/product/updateBaseImages.sh -o /tmp/updateBaseImages.sh
 chmod +x /tmp/updateBaseImages.sh
 cd ${WORKSPACE}/sources
   git checkout --track origin/''' + SOURCE_BRANCH + ''' || true
@@ -118,8 +118,7 @@ done
 
 cp -f ${SOURCEDOCKERFILE} ${WORKSPACE}/target/Dockerfile
 
-# TODO should this be a branch instead of just master?
-CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/VERSION`
+CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + GIT_BRANCH + '''/dependencies/VERSION`
 #apply patches
 sed -i ${WORKSPACE}/target/Dockerfile \
   -e "s#FROM registry.redhat.io/#FROM #g" \
@@ -179,7 +178,7 @@ cause=${QUAY_REPO_PATH}+respin+by+${BUILD_TAG}&\
 GIT_BRANCH=''' + GIT_BRANCH + '''&\
 GIT_PATHs=containers/codeready-workspaces-${QRP}&\
 QUAY_REPO_PATHs=${QUAY_REPO_PATH}&\
-JOB_BRANCH=master&\
+JOB_BRANCH=${CRW_VERSION}&\
 FORCE_BUILD=true&\
 SCRATCH=''' + SCRATCH + '''"
   done

--- a/dependencies/che-plugin-registry/Jenkinsfile
+++ b/dependencies/che-plugin-registry/Jenkinsfile
@@ -2,13 +2,13 @@
 
 // PARAMETERS for this pipeline:
 // def FORCE_BUILD = "false"
-// def SOURCE_BRANCH = "master" // 7.3.x or 7.7.x :: branch of source repo from which to find and sync commits to pkgs.devel repo
+// def SOURCE_BRANCH = "crw-2.4-rhel-8" // branch of GH and pkgs.devel repos to sync commits
 
 // TODO source from eclipse/che-plugin-registry too
 
 def SOURCE_REPO = "redhat-developer/codeready-workspaces" //source repo from which to find and sync commits to pkgs.devel repo
 def GIT_PATH = "containers/codeready-workspaces-pluginregistry" // dist-git repo to use as target
-def GIT_BRANCH = "crw-2.2-rhel-8" // target branch in dist-git repo, eg., crw-2.2-rhel-8
+def GIT_BRANCH = "crw-2.4-rhel-8" // target branch in dist-git repo, eg., crw-2.4-rhel-8
 def SCRATCH = "false"
 def PUSH_TO_QUAY = "true"
 def QUAY_PROJECT = "pluginregistry" // also used for the Brew dockerfile params
@@ -75,7 +75,7 @@ if [[ -f ${SOURCEDIR}/build/dockerfiles/rhel.Dockerfile ]]; then
 fi
 
 # REQUIRE: skopeo
-curl -L -s -S https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/product/updateBaseImages.sh -o /tmp/updateBaseImages.sh
+curl -L -s -S https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + SOURCE_BRANCH + '''/product/updateBaseImages.sh -o /tmp/updateBaseImages.sh
 chmod +x /tmp/updateBaseImages.sh
 cd ${WORKSPACE}/sources
   git checkout --track origin/''' + SOURCE_BRANCH + ''' || true
@@ -92,7 +92,7 @@ cd ${WORKSPACE}/sources
 
   # Check if che-machine-exec and che-theia plugins are current in upstream repo and if not, add them
   pushd ${SOURCEDIR} >/dev/null
-  ./build/scripts/add_che_plugins.sh $(cat ${WORKSPACE}/sources/pom.xml | grep -E "<che.version>" | sed -r -e "s#.+<che.version>(.+)</che.version>#\\1#")
+  ./build/scripts/add_che_plugins.sh -b ''' + branchToBuildCRW + ''' $(cat ${WORKSPACE}/sources/pom.xml | grep -E "<che.version>" | sed -r -e "s#.+<che.version>(.+)</che.version>#\\1#")
   popd >/dev/null
 
   OLD_SHA=$(git rev-parse HEAD) # echo ${OLD_SHA:0:8}
@@ -138,8 +138,7 @@ done
 
 cp -f ${SOURCEDOCKERFILE} ${WORKSPACE}/target/Dockerfile
 
-# TODO should this be a branch instead of just master?
-CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/VERSION`
+CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + SOURCE_BRANCH + '''/dependencies/VERSION`
 # apply patches to transform CRW upstream to pkgs.devel version
 sed -i ${WORKSPACE}/target/Dockerfile --regexp-extended \
   `# Replace image used for registry with rhel8/httpd-24` \
@@ -315,7 +314,7 @@ cause=${QUAY_REPO_PATH}+respin+by+${BUILD_TAG}&\
 GIT_BRANCH=''' + GIT_BRANCH + '''&\
 GIT_PATHs=containers/codeready-workspaces-${QRP}&\
 QUAY_REBUILD_PATH=${QUAY_REPO_PATH}&\
-JOB_BRANCH=master&\
+JOB_BRANCH=${CRW_VERSION}&\
 FORCE_BUILD=true&\
 SCRATCH=''' + SCRATCH + '''"
   done

--- a/dependencies/che-plugin-registry/build/scripts/add_che_plugins.sh
+++ b/dependencies/che-plugin-registry/build/scripts/add_che_plugins.sh
@@ -3,11 +3,12 @@
 # Used to create new che-theia and machine-exec plugins and commit changes more easily.
 
 NOCOMMIT=0
-BRANCH="master"
+BRANCH="crw-2.4-rhel-8"
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     '-n'|'--no-commit') NOCOMMIT=1; shift 0;;
+    '-b') BRANCH="$2"; shift 1;;
     *) VERSION="$1"; shift 0;;
   esac
   shift 1
@@ -16,7 +17,7 @@ done
 usage ()
 {
   echo "Usage:   $0 [VERSION TO ADD] [--no-commit]"
-  echo "Example: $0 7.9.3"; echo
+  echo "Example: $0 7.17.0 -b crw-2.4-rhel-8"; echo
 }
 
 if [[ ! ${VERSION} ]]; then

--- a/dependencies/che-pluginbroker/Jenkinsfile
+++ b/dependencies/che-pluginbroker/Jenkinsfile
@@ -2,13 +2,13 @@
 
 // PARAMETERS for this pipeline:
 // def FORCE_BUILD = "false"
-// def SOURCE_BRANCH = "crw-2.1" // ref/tags/v0.24.0, or crw-2.1, or master :: branch of source repo from which to find and sync commits to pkgs.devel repo
+// def SOURCE_BRANCH = "v3.2.x" // branch of source repo from which to find and sync commits to pkgs.devel repo
 
 def SOURCE_REPO = "eclipse/che-plugin-broker" //source repo from which to find and sync commits to pkgs.devel repo 
 def GIT_PATH1 = "containers/codeready-workspaces-pluginbroker-metadata" // dist-git repo to use as target
 def GIT_PATH2 = "containers/codeready-workspaces-pluginbroker-artifacts" // dist-git repo to use as target
 
-def GIT_BRANCH = "crw-2.2-rhel-8" // target branch in dist-git repo, eg., crw-2.2-rhel-8
+def GIT_BRANCH = "crw-2.4-rhel-8" // target branch in dist-git repo, eg., crw-2.4-rhel-8
 def SCRATCH = "false"
 def PUSH_TO_QUAY = "true"
 def QUAY_PROJECT1 = "pluginbroker-metadata" // also used for the Brew dockerfile params
@@ -71,7 +71,7 @@ klist # verify working
 hasChanged=0
 
 # REQUIRE: skopeo
-curl -L -s -S https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/product/updateBaseImages.sh -o /tmp/updateBaseImages.sh
+curl -L -s -S https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + GIT_BRANCH + '''/product/updateBaseImages.sh -o /tmp/updateBaseImages.sh
 chmod +x /tmp/updateBaseImages.sh 
 cd ${WORKSPACE}/sources
   git checkout --track origin/''' + SOURCE_BRANCH + ''' || true
@@ -144,8 +144,7 @@ for targetN in target1 target2; do
       QUAY_PROJECT="''' + QUAY_PROJECT2 + '''"
     fi
 
-    # TODO should this be a branch instead of just master?
-    CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/VERSION`
+    CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + GIT_BRANCH + '''/dependencies/VERSION`
     #apply patches
     if [[ ${SOURCEDOCKERFILE} != "" ]] && [[ ${TARGETDOCKERFILE} != "" ]]; then
       sed ${SOURCEDOCKERFILE} \
@@ -207,7 +206,7 @@ cause=${QUAY_REPO_PATH}+respin+by+${BUILD_TAG}&\
 GIT_BRANCH=''' + GIT_BRANCH + '''&\
 GIT_PATHs=containers/codeready-workspaces-${QRP}&\
 QUAY_REPO_PATHs=${QUAY_REPO_PATH}&\
-JOB_BRANCH=master&\
+JOB_BRANCH=${CRW_VERSION}&\
 FORCE_BUILD=true&\
 SCRATCH=''' + SCRATCH + '''"
   done

--- a/dependencies/kubernetes-image-puller/Jenkinsfile
+++ b/dependencies/kubernetes-image-puller/Jenkinsfile
@@ -7,7 +7,7 @@
 def SOURCE_REPO = "che-incubator/kubernetes-image-puller" //source repo from which to find and sync commits to pkgs.devel repo
 def GIT_PATH = "containers/codeready-workspaces-imagepuller" // dist-git repo to use as target
 
-def GIT_BRANCH = "crw-2.2-rhel-8" // target branch in dist-git repo, eg., crw-2.2-rhel-8
+def GIT_BRANCH = "crw-2.4-rhel-8" // target branch in dist-git repo, eg., crw-2.4-rhel-8
 def SCRATCH = "false"
 def PUSH_TO_QUAY = "true"
 def QUAY_PROJECT = "imagepuller" // also used for the Brew dockerfile params
@@ -69,7 +69,7 @@ hasChanged=0
 SOURCEDOCKERFILE=${WORKSPACE}/sources/docker/rhel.Dockerfile
 
 # REQUIRE: skopeo
-curl -L -s -S https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/product/updateBaseImages.sh -o /tmp/updateBaseImages.sh
+curl -L -s -S https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + GIT_BRANCH + '''/product/updateBaseImages.sh -o /tmp/updateBaseImages.sh
 chmod +x /tmp/updateBaseImages.sh
 cd ${WORKSPACE}/sources
   git checkout --track origin/''' + SOURCE_BRANCH + ''' || true
@@ -141,8 +141,7 @@ done
 
 cp -f ${SOURCEDOCKERFILE} ${WORKSPACE}/target/Dockerfile
 
-# TODO should this be a branch instead of just master?
-CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/master/dependencies/VERSION`
+CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + GIT_BRANCH + '''/dependencies/VERSION`
 # apply patches to transform Che upstream to pkgs.devel version
 sed -i ${WORKSPACE}/target/Dockerfile --regexp-extended \
   `# Replace ubi8 with rhel8 version` \
@@ -271,7 +270,7 @@ cause=${QUAY_REPO_PATH}+respin+by+${BUILD_TAG}&\
 GIT_BRANCH=''' + GIT_BRANCH + '''&\
 GIT_PATHs=containers/codeready-workspaces-${QRP}&\
 QUAY_REPO_PATHs=${QUAY_REPO_PATH}&\
-JOB_BRANCH=master&\
+JOB_BRANCH=${CRW_VERSION}&\
 FORCE_BUILD=true&\
 SCRATCH=''' + SCRATCH + '''"
   done

--- a/dependencies/send-email-qe-build-list.Jenkinsfile
+++ b/dependencies/send-email-qe-build-list.Jenkinsfile
@@ -1,9 +1,7 @@
 #!/usr/bin/env groovy
 
-def SOURCE_BRANCH = "master"
-
 // PARAMETERS for this pipeline:
-// getLatestImageTagsFlags="--crw23" # placeholder for flag to pass to getLatestImageTags.sh
+// getLatestImageTagsFlags="--crw24" # placeholder for flag to pass to getLatestImageTags.sh
 // mailSubject  - subject to put on the email, eg., CRW 2.3.0.RC-mm-yy ready for QE
 // errataURL - URL for the errata, eg., https://errata.devel.redhat.com/errata/container/56923
 // unresolvedCriticalsBlockersURL - URL for unresolved blockers/criticals, eg., Unresolved criticals/blockers:

--- a/dependencies/update-digests.Jenkinsfile
+++ b/dependencies/update-digests.Jenkinsfile
@@ -1,8 +1,8 @@
 #!/usr/bin/env groovy
 
 // PARAMETERS for this pipeline:
-// SOURCE_BRANCH = "master"
-// getLatestImageTagsFlags="--crw23" # placeholder for flag to pass to getLatestImageTags.sh
+// SOURCE_BRANCH = "crw-2.4-rhel-8"
+// getLatestImageTagsFlags="--crw24" # placeholder for flag to pass to getLatestImageTags.sh
 
 def errorOccurred = false
 timeout(120) {

--- a/devdoc/building/building-crw.adoc
+++ b/devdoc/building/building-crw.adoc
@@ -147,9 +147,10 @@ mkdir -p ${WORKSPACE} && cd ${WORKSPACE}
 git clone https://github.com/redhat-developer/codeready-workspaces-deprecated
 cd codeready-workspaces-deprecated/operator-installer
 
-git checkout 6.19.x # for CRW 1.x
-
-# or git checkout master # for CRW 2.x - TODO: update this script to work w/ master branch too
+# git checkout 6.19.x # for CRW 1.x
+# git checkout master # for CRW 2.0 - 2.3
+git checkout crw-2.4-rhel-8 # for 2.4
+# TODO: update this script to work w/ latest 2.x
 
 # delete existing crw deployment if it exists
 oc login 192.168.$YOUR_IP:8443 -u system -p admin && \
@@ -245,7 +246,7 @@ mvn clean install
 +
 ```
 [INFO] Reactor Summary:
-[INFO] 
+[INFO]
 [INFO] CRW :: Parent 2.1.0.GA ............................. SUCCESS [  3.140 s]
 [INFO] CRW :: Assembly :: Parent .......................... SUCCESS [  0.092 s]
 [INFO] CRW :: Assembly :: Dashboard ....................... SUCCESS [  3.631 s]

--- a/product/branding/README.adoc
+++ b/product/branding/README.adoc
@@ -2,6 +2,5 @@ This folder contains source files provided by Red Hat Brand for use in CodeReady
 
 For the adapted files actually used in the product, see:
 
-* Dashboard - https://github.com/redhat-developer/codeready-workspaces/tree/master/assembly/codeready-workspaces-assembly-dashboard-war/src/main/webapp/assets/branding
-* Theia IDE - https://github.com/redhat-developer/codeready-workspaces-theia/tree/master/conf/theia/branding
-
+* Dashboard - https://github.com/redhat-developer/codeready-workspaces/tree/crw-2.4-rhel-8/assembly/branding
+* Theia IDE - https://github.com/redhat-developer/codeready-workspaces-theia/tree/crw-2.4-rhel-8/conf/theia/branding

--- a/product/getCommitSHAForTag.sh
+++ b/product/getCommitSHAForTag.sh
@@ -28,7 +28,7 @@ exit
 }
 
 # candidateTag="crw-2.0-rhel-8-candidate" # 2.0, 2.1
-candidateTag="crw-2.2-rhel-8-container-candidate" # 2.2
+candidateTag="crw-2.4-rhel-8-container-candidate" # 2.2
 
 if [[ $# -lt 1 ]]; then usage; fi
 

--- a/product/getLatestImageTags.sh
+++ b/product/getLatestImageTags.sh
@@ -30,8 +30,8 @@ if [[ ! -x /usr/bin/jq ]]; then
 	exit 1
 fi
 
-candidateTag="crw-2.2-rhel-8-container-candidate"
-BASETAG=2.3 # tag to search for in quay
+candidateTag="crw-2.4-rhel-8-container-candidate"
+BASETAG=2.4 # tag to search for in quay
 
 CRW22_CONTAINERS_RHCC="\
 codeready-workspaces/crw-2-rhel8-operator-metadata \
@@ -119,8 +119,9 @@ CONTAINERS=""
 #   case $1 in
 for key in "$@"; do
   case $key in
-    '--crw23') CONTAINERS="${CRW22_CONTAINERS_RHCC}";         candidateTag="crw-2.2-rhel-8-container-candidate"; BASETAG=2.3; shift 0;; 
-    '--crw22') CONTAINERS="${CRW22_CONTAINERS_RHCC}";         candidateTag="crw-2.2-rhel-8-container-candidate"; BASETAG=2.2; shift 0;;
+    '--crw24') CONTAINERS="${CRW22_CONTAINERS_RHCC}"; candidateTag="crw-2.4-rhel-8-container-candidate"; BASETAG=2.4; shift 0;; 
+    '--crw23') CONTAINERS="${CRW22_CONTAINERS_RHCC}"; candidateTag="crw-2.2-rhel-8-container-candidate"; BASETAG=2.3; shift 0;; 
+    '--crw22') CONTAINERS="${CRW22_CONTAINERS_RHCC}"; candidateTag="crw-2.2-rhel-8-container-candidate"; BASETAG=2.2; shift 0;;
     '-c') CONTAINERS="${CONTAINERS} $2"; shift 1;;
     '-x') EXCLUDES="$2"; shift 1;;
     '-q') QUIET=1; shift 0;;

--- a/product/tagRelease.sh
+++ b/product/tagRelease.sh
@@ -13,12 +13,12 @@
 set -ex
 
 # defaults
-crw_repos_branch=master 
-pkgs_devel_branch=crw-2.2-rhel-8
+crw_repos_branch=crw-2.4-rhel-8
+pkgs_devel_branch=crw-2.4-rhel-8
 
 if [[ $# -lt 4 ]]; then
 	echo "Usage: $0 -t CRW_TAG -o CHE_OPERATOR_BRANCH [-gh CRW_GH_BRANCH] [-pd PKGS_DEVEL_BRANCH]"
-	echo "Example: $0 -t 2.2.0.GA -o 7.14.x -gh master -pd crw-2.2-rhel-8"
+	echo "Example: $0 -t 2.4.0.GA -o 7.17.x -gh crw-2.4-rhel-8 -pd crw-2.4-rhel-8"
 	exit 1
 fi
 

--- a/product/updateBaseImages.sh
+++ b/product/updateBaseImages.sh
@@ -27,10 +27,10 @@ fi
 QUIET=0 	# less output - omit container tag URLs
 VERBOSE=0	# more output
 WORKDIR=`pwd`
-BRANCH=crw-2.2-rhel-8 # not master
+BRANCH=crw-2.4-rhel-8 # or another branch, depends on the repo
 DOCKERFILE="Dockerfile" # or "rhel.Dockerfile"
 MAXDEPTH=2
-PR_BRANCH="pr-master-new-base-images-$(date +%s)"
+PR_BRANCH="pr-new-base-images-$(date +%s)"
 OPENBROWSERFLAG="" # if a PR is generated, open it in a browser
 docommit=1 # by default DO commit the change
 dopush=1 # by default DO push the change
@@ -54,11 +54,12 @@ checkrecentupdates () {
 
 usage () {
 	echo "Usage:   $0 -b [BRANCH] [-w WORKDIR] [-f DOCKERFILE] [-maxdepth MAXDEPTH]"
-	echo "Example: $0 -b crw-2.2-rhel-8 -w $(pwd) -f rhel.Dockerfile -maxdepth 2"
+	echo "Downstream Example: $0 -b crw-2.4-rhel-8 -w $(pwd) -f rhel.Dockerfile -maxdepth 2"
+	echo "Upstream   Example: $0 -b master -w dockerfiles/ -f \*from.dockerfile -maxdepth 5 -o -prb pr-new-theia-base-images"
 	echo "Options: 
 	--no-commit, -n    do not commit to BRANCH
 	--no-push, -p      do not push to BRANCH
-	-prb               set a PR_BRANCH; default: pr-master-new-base-images-(timestamp)
+	-prb               set a PR_BRANCH; default: pr-new-base-images-(timestamp)
 	-o                 open browser if PR generated
 	-q, -v             quiet, verbose output
 	--help, -h         help
@@ -216,7 +217,7 @@ for d in $(find ${WORKDIR} -maxdepth ${MAXDEPTH} -name ${DOCKERFILE} | sort); do
 
 									# shellcheck disable=SC2181
 									if [[ $? -gt 0 ]] || [[ $PUSH_TRY == *"protected branch hook declined"* ]]; then
-										# create pull request for master branch, as branch is restricted
+										# create pull request if target branch is restricted access
 										git branch "${PR_BRANCH}" || true
 										git checkout "${PR_BRANCH}" || true
 										git pull origin "${PR_BRANCH}" || true


### PR DESCRIPTION
bump to new GIT_BRANCH = crw-2.4-rhel-8; use that branch instead of master; pass branch to add_che_plugins.sh script

Change-Id: I6b59bb4dcddff7e3f46fb967462884b709bd86c6
Signed-off-by: nickboldt <nboldt@redhat.com>

bump to new GIT_BRANCH = crw-2.4-rhel-8; use that branch instead of master

Change-Id: Id68e1514da17fe3d39f0b83c7cd36e2aaea48856
Signed-off-by: nickboldt <nboldt@redhat.com>

bump to new GIT_BRANCH = crw-2.4-rhel-8; use that branch instead of master

Change-Id: I1d165e34d73bbb5e2c1c012453c17421955cb6b4
Signed-off-by: nickboldt <nboldt@redhat.com>

bump to new GIT_BRANCH = crw-2.4-rhel-8; use that branch instead of master

Change-Id: Id5967e2bf339b30d672f25d712bd88f8297f0503
Signed-off-by: nickboldt <nboldt@redhat.com>

bump to new GIT_BRANCH = crw-2.4-rhel-8; use that branch instead of master

Change-Id: Ic1b459d87ed780a0e79ec048ecb468ee606068fb
Signed-off-by: nickboldt <nboldt@redhat.com>

bump to new GIT_BRANCH = crw-2.4-rhel-8; use that branch instead of master

Change-Id: I8c8db87599dea94a69b2640750aeb8ea296093d8
Signed-off-by: nickboldt <nboldt@redhat.com>