### PR TITLE
CRW-1193 ensure swap_images happens after resources.tgz is expanded 

### DIFF
--- a/dependencies/che-devfile-registry/Jenkinsfile
+++ b/dependencies/che-devfile-registry/Jenkinsfile
@@ -160,7 +160,7 @@ sed -i ${WORKSPACE}/targetdwn/Dockerfile --regexp-extended \
   -e 's|^[^#]*--from=offline-builder.*|# &|' \
   -e '/COPY --from=builder/a COPY --from=builder /build/resources /var/www/html/resources' \
   `# Enable cache_projects.sh` \
-  -e '\\|write_image_digests.sh|i # Cache projects in CRW \\
+  -e '\\|swap_images.sh|i # Cache projects in CRW \\
 COPY ./build/dockerfiles/rhel.cache_projects.sh resources.tgz /tmp/ \\
 RUN /tmp/rhel.cache_projects.sh /build/ && rm -rf /tmp/rhel.cache_projects.sh /tmp/resources.tgz \\
 '

--- a/dependencies/che-plugin-registry/Jenkinsfile
+++ b/dependencies/che-plugin-registry/Jenkinsfile
@@ -162,7 +162,7 @@ sed -i ${WORKSPACE}/targetdwn/Dockerfile --regexp-extended \
   -e '/^ *FROM builder AS offline-builder/,+3 s|.*|# &|' \
   -e 's|^[^#]*--from=offline-builder.*|# &|' \
   `# Enable cache_artifacts.sh` \
-  -e '\\|write_image_digests.sh|i # Cache projects in CRW \\
+  -e '\\|swap_images.sh|i # Cache projects in CRW \\
 COPY ./build/dockerfiles/rhel.cache_artifacts.sh resources.tgz /tmp/ \\
 RUN /tmp/rhel.cache_artifacts.sh /build/v3/ && rm -rf /tmp/rhel.cache_artifacts.sh /tmp/resources.tgz \\
 '


### PR DESCRIPTION


<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?

 ensure swap_images happens after resources.tgz is expanded to prevent overwriting

### What issues does this PR fix or reference?

CRW-1193

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
