### PR TITLE
latest golang plugin should be using latest stacks-golang

### DIFF
--- a/dependencies/che-plugin-registry/v3/plugins/golang/go/0.16.1/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/golang/go/0.16.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2020-09-03'
 spec:
   containers:
-    - image: "registry.redhat.io/codeready-workspaces/stacks-golang-rhel8:2.3"
+    - image: "registry.redhat.io/codeready-workspaces/stacks-golang-rhel8:2.4"
       name: vscode-go
       memoryLimit: '512Mi'
       args:


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?

latest golang plugin should be using latest stacks-golang

### What issues does this PR fix or reference?

fix error:
failed to fetch plugin meta.yaml from URL 'https://plugin-registry-crw.apps.qe2-s390x.psi.redhat.com/v3/plugins/ms-vscode/go/latest/meta.yaml'

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
