### PR TITLE
fix incorrect sha for eap xp1 image on s390x

### DIFF
--- a/dependencies/che-devfile-registry/build/scripts/find_image.sh
+++ b/dependencies/che-devfile-registry/build/scripts/find_image.sh
@@ -20,6 +20,7 @@ for url in "${image_urls[@]}" ; do
   manifest="$(skopeo --override-arch $ARCH inspect --tls-verify=false "docker://${url}" 2>> "$LOG_FILE")"
   if [[ ! -z "$manifest" ]] ; then
     echo "$manifest"
+    cat $LOG_FILE >&2
     exit 0
   fi
 done

--- a/dependencies/che-devfile-registry/build/scripts/swap_images.sh
+++ b/dependencies/che-devfile-registry/build/scripts/swap_images.sh
@@ -14,7 +14,8 @@ devfiles=$($SCRIPT_DIR/list_yaml.sh "$YAML_ROOT")
 # Note: optional -f flag will force this transformation even on an incompatible architecture,
 # so we can call this script from crw-operator/build/scripts/insert-related-images-to-csv.sh
 if [[ "$(uname -m)" != "x86_64" ]] || [[ "$2" == "-f" ]]; then 
-    sed -E -i 's|eap-xp1-openjdk11-openshift-rhel8:.*|eap-xp1-openj9-11-openshift-rhel8:1.0|g' $devfiles
+    # ensure to use full tag.   ex. 1.0-12 instead of 1.0--as 1.0 might be different on various registries when using find_image.sh
+    sed -E -i 's|eap-xp1-openjdk11-openshift-rhel8:.*|eap-xp1-openj9-11-openshift-rhel8:1.0-12|g' $devfiles
     sed -E -i 's|plugin-java8-rhel8|plugin-java8-openj9-rhel8|g' $devfiles
     sed -E -i 's|plugin-java11-rhel8|plugin-java11-openj9-rhel8|g' $devfiles
 fi

--- a/dependencies/che-plugin-registry/build/scripts/find_image.sh
+++ b/dependencies/che-plugin-registry/build/scripts/find_image.sh
@@ -20,6 +20,7 @@ for url in "${image_urls[@]}" ; do
   manifest="$(skopeo --override-arch $ARCH inspect --tls-verify=false "docker://${url}" 2>> "$LOG_FILE")"
   if [[ ! -z "$manifest" ]] ; then
     echo "$manifest"
+    cat $LOG_FILE >&2
     exit 0
   fi
 done

--- a/dependencies/che-plugin-registry/build/scripts/swap_images.sh
+++ b/dependencies/che-plugin-registry/build/scripts/swap_images.sh
@@ -14,7 +14,8 @@ devfiles=$($SCRIPT_DIR/list_yaml.sh "$YAML_ROOT")
 # Note: optional -f flag will force this transformation even on an incompatible architecture,
 # so we can call this script from crw-operator/build/scripts/insert-related-images-to-csv.sh
 if [[ "$(uname -m)" != "x86_64" ]] || [[ "$2" == "-f" ]]; then 
-    sed -E -i 's|eap-xp1-openjdk11-openshift-rhel8:.*|eap-xp1-openj9-11-openshift-rhel8:1.0|g' $devfiles
+    # ensure to use full tag.   ex. 1.0-12 instead of 1.0--as 1.0 might be different on various registries when using find_image.sh
+    sed -E -i 's|eap-xp1-openjdk11-openshift-rhel8:.*|eap-xp1-openj9-11-openshift-rhel8:1.0-12|g' $devfiles
     sed -E -i 's|plugin-java8-rhel8|plugin-java8-openj9-rhel8|g' $devfiles
     sed -E -i 's|plugin-java11-rhel8|plugin-java11-openj9-rhel8|g' $devfiles
 fi


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?

registry.redhat.io will always error out in brew when trying to download manifest due to no authentication, so registry-proxy.engineering.redhat.com is used instead.  Since the swap_images.sh script was using tag 1.0 instead of the actual GA release of 1.0-12 the latest internal sha was being used instead.

Have also added some additional log info to show what alternative is being used for each digest being written.


### What issues does this PR fix or reference?

fix incorrect sha for eap xp1 image on s390x
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
