### PR TITLE
RHDEVDOCS-2102 content is now in end user...

### DIFF
--- a/assembly/branding/product.json.template
+++ b/assembly/branding/product.json.template
@@ -33,7 +33,7 @@
     "factory" : "@@crw.docs.baseurl@@/html-single/end-user_guide/index#overriding-devfile-values-using-factory-parameters_configuring-a-workspace-using-a-devfile",
     "organization": "@@crw.docs.baseurl@@/html-single/administration_guide/index#managing-users_crw",
     "converting": "https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/2.0/html-single/end-user_guide/index#converting-a-codeready-workspaces-1.2-workspace-to-a-codeready-workspaces-2.0-devfile",
-    "certificate": "@@crw.docs.baseurl@@/html-single/installation_guide/index#_installing_codeready_workspaces_on_openshift_container_platform",
+    "certificate": "@@crw.docs.baseurl@@/html-single/end-user_guide/index#importing-certificates-to-browsers_crw",
     "general": "@@crw.docs.baseurl@@/"
   }
 }


### PR DESCRIPTION
RHDEVDOCS-2102 content is now in end user guide under 'importing certificates' section

Change-Id: I8dc0388857349b83800272f0e9afc736ddf02b55
Signed-off-by: nickboldt <nboldt@redhat.com>