### PR TITLE
Fix the command to debug spring app

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_spring-boot-http-booster/devfile.yaml
@@ -54,7 +54,7 @@ commands:
       - workdir: '${CHE_PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec
         command: >-
-         mvn  -Duser.home=${HOME} spring-boot:run -Drun.jvmArguments="-Xdebug
+         mvn  -Duser.home=${HOME} spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug
           -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005"
         component: maven
   - name: 4. Run tests


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Fix a command  to run remote debugging in spring_boot_http_booster application.
`-Dspring-boot.run.jvmArguments` attribute should be used with the new version of spring boot (2.x.x)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1234
