### PR TITLE
fixup leading whitespace in generated rsync exclude files

### DIFF
--- a/dependencies/configbump/Jenkinsfile
+++ b/dependencies/configbump/Jenkinsfile
@@ -57,21 +57,17 @@ timeout(30) {
                     OLD_SHA = util.getLastCommitSHA("${WORKSPACE}/targetdwn/${SYNC_REPO}")
                     println "Got OLD_SHA in targetdwn/${SYNC_REPO} folder: " + OLD_SHA
 
-                    writeFile file: "rsync-upstream-exclude", text: '''
-                    .github
-                    .gitattributes
-                    '''
+                    writeFile file: "rsync-upstream-exclude", text: '''.github
+.gitattributes'''
                     // ignore files that are ONLY in downstream (not midstream or upstream)
-                    writeFile file: "rsync-brew-exclude", text: '''
-                    sources
-                    get-sources-jenkins.sh
-                    cvp.yml
-                    tests/
-                    content_sets.yml
-                    content_sets.repo
-                    container.yaml
-                    .gitignore
-                    '''
+                    writeFile file: "rsync-brew-exclude", text: '''sources
+get-sources-jenkins.sh
+cvp.yml
+tests/
+content_sets.yml
+content_sets.repo
+container.yaml
+.gitignore'''
                     sh('''
                       rsync -avhz --checksum --exclude-from ${WORKSPACE}/rsync-upstream-exclude --exclude-from ${WORKSPACE}/rsync-brew-exclude --exclude .git/ --exclude .github/ --exclude .gitignore \
                         ${WORKSPACE}/sources/''' + SYNC_REPO + '''/ ${WORKSPACE}/targetdwn/''' + SYNC_REPO


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?

fixup leading whitespace in generated rsync exclude files

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
