### PR TITLE
Update version used IntelliJ Idea IC

### DIFF
--- a/dependencies/che-editor-intellij-community/devfiles/meta.yaml
+++ b/dependencies/che-editor-intellij-community/devfiles/meta.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 publisher: eclipse
 name: ideaIC-NOVNC
-version: 2020.2.3
+version: 2020.2.2
 type: Che Editor
 displayName:  IntelliJ IDEA Community Edition
 title:  IntelliJ IDEA Community Edition (in browser using noVNC) as editor for Eclipse Che
 description:  IntelliJ IDEA Community Edition running on the Web with noVNC
 icon: https://resources.jetbrains.com/storage/products/intellij-idea/img/meta/intellij-idea_logo_300x300.png
 category: Editor
-repository: https://github.com/che-incubator/che-editor-intellij-community
+repository: https://github.com/che-incubator/jetbrains-editor-images
 firstPublicationDate: "2020-09-25"
 spec:
   endpoints:
@@ -25,7 +25,7 @@ spec:
      image: "quay.io/crw/plugin-intellij-rhel8:2.5"
      mountSources: true
      volumes:
-         - mountPath: "/JetBrains/ideaIC"
+         - mountPath: "/JetBrains/IdeaIC"
            name: idea-configuration
      ports:
          - exposedPort: 8080


### PR DESCRIPTION
Set up correct version of used JetBrains product and fix https://issues.redhat.com/browse/CRW-1364 by using correct volume mount.

For Idea IC 2020.2.2 correct mount path should be `/JetBrains/IdeaIC`
For Idea IC 2020.2.3 correct mount path should be `/JetBrains/ideaIC`


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1364
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
N/A
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
