### PR TITLE
fix preLaunchTask in dotnet stack

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/05_dotnet/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_dotnet/devfile.yaml
@@ -69,7 +69,7 @@ commands:
                     "args": [],
                     "name": ".NET Core Launch (console)",
                     "stopAtEntry": true,
-                    "preLaunchTask": "build",
+                    "preLaunchTask": "2. Build",
                     "console": "internalConsole"
                   }
               ]


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Fixes the problem with dotnet debugger. Since the name of build command was changed, need to change it in debug configuration as well.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
