### PR TITLE
Fix README rendering

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ NOTE: the so-called master branch is deprecated and is no longer kept up to date
 
 For the latest release, see the crw-2.y-rhel-8 branch with the largest y value.
 
------
+---
 
 This repository hosts CodeReady Workspaces assembly that mainly inherits Eclipse Che artifacts and repackages some of them:
 


### PR DESCRIPTION
### What does this PR do?

Currently most of the README is rendered as `preformatted code`:

![image](https://user-images.githubusercontent.com/606959/102117947-4b2c7a80-3e3f-11eb-89d8-5aea19435ea3.png)

This PR fix that.
