### PR TITLE
Fix .m2 volume path

### DIFF
--- a/dependencies/che-plugin-registry/v3/plugins/redhat/java/0.63.0/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/java/0.63.0/meta.yaml
@@ -21,7 +21,7 @@ spec:
       - -c
       - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
     volumes:
-    - mountPath: "/home/theia/.m2"
+    - mountPath: "/home/jboss/.m2"
       name: m2
   extensions:
     - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix

--- a/dependencies/che-plugin-registry/v3/plugins/redhat/java8/0.63.0/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/redhat/java8/0.63.0/meta.yaml
@@ -21,7 +21,7 @@ spec:
       - -c
       - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
     volumes:
-    - mountPath: "/home/theia/.m2"
+    - mountPath: "/home/jboss/.m2"
       name: m2
   extensions:
     - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Changes .m2 volume from /home/theia/.m2 to /home/jboss/.m2 in redhat/java and redhat/java8 plugins 

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1418

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
