### PR TITLE
Use a dedicated Che Dashboard Version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ import groovy.transform.Field
 @Field String branchToBuildDev = "refs/tags/19"
 @Field String branchToBuildParent = "refs/tags/7.15.0"
 @Field String branchToBuildChe = "7.20.x"
+@Field String branchToBuildCheDashboard = "7.20.x"
 @Field String MIDSTM_BRANCH = "crw-2.5-rhel-8" // target branch in GH repo, eg., crw-2.5-rhel-8
 
 @Field String PUSH_TO_QUAY = "true"
@@ -202,7 +203,7 @@ PREVVERSION="${BASE}.${PREV}"; echo ${PREVVERSION}
 
 		echo "===== Build che-dashboard =====>"
 		checkout([$class: 'GitSCM', 
-			branches: [[name: "${branchToBuildChe}"]], 
+			branches: [[name: "${branchToBuildCheDashboard}"]],
 			doGenerateSubmoduleConfigurations: false, 
 			poll: true,
 			extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: "${CHE_DB_path}"]], 


### PR DESCRIPTION
### What does this PR do?
Eclipse Che has a plan to switch to a new React-based Dashboard in 7.25.
But the decision that CRW 2.7(Che 7.26) should switch to a new dashboard is not made.
So, this PR introduces a dedicated parameter to be able to stick to an old Dashboard version which is angular-based.

P.S. Probably more changes are needed to make it work, like setting this parameter somewhere...
This PR is more to track all stuff we need to track and after the decision is made - it will need to be closed or finalized.

### What issues does this PR fix or reference?
It's related to switch to Dashboard Next within https://github.com/eclipse/che/issues/18348

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
