### PR TITLE
Align Dockerfile with upstream to prevent invalid images from being built

### DIFF
--- a/dependencies/che-devfile-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-devfile-registry/build/dockerfiles/Dockerfile
@@ -30,13 +30,15 @@ RUN ./list_referenced_images.sh devfiles > /build/devfiles/external_images.txt
 RUN chmod -R g+rwX /build/devfiles
 
 FROM docker.io/httpd:2.4.43-alpine AS registry
-# Allow htaccess
-RUN sed -i 's|    AllowOverride None|    AllowOverride All|' /usr/local/apache2/conf/httpd.conf && \
+RUN apk add --no-cache bash && \
+    # Allow htaccess
+    sed -i 's|    AllowOverride None|    AllowOverride All|' /usr/local/apache2/conf/httpd.conf && \
     sed -i 's|Listen 80|Listen 8080|' /usr/local/apache2/conf/httpd.conf && \
     mkdir -m 777 /usr/local/apache2/htdocs/devfiles && \
     mkdir -p /var/www && ln -s /usr/local/apache2/htdocs /var/www/html && \
     chmod -R g+rwX /usr/local/apache2 && \
-    echo "ServerName localhost" >> /usr/local/apache2/conf/httpd.conf
+    echo "ServerName localhost" >> /usr/local/apache2/conf/httpd.conf && \
+    apk add --no-cache coreutils
 COPY .htaccess README.md /usr/local/apache2/htdocs/
 COPY --from=builder /build/devfiles /usr/local/apache2/htdocs/devfiles
 COPY ./images /usr/local/apache2/htdocs/images


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?

Prevents errors like:

`standard_init_linux.go:211: exec user process caused "no such file or directory"`

from occurring when building with the alpine based Dockerfile.

### What issues does this PR fix or reference?
N/A
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
