### PR TITLE
Fix Run in debug mode command for Spring 2.x

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java-jboss-fuse/devfile.yaml
@@ -36,6 +36,10 @@ components:
     endpoints:
       - name: '8080'
         port: 8080
+      - name: debug
+        attributes:
+          public: 'false'
+        port: 5005
     mountSources: true
     volumes:
       - name: m2
@@ -63,7 +67,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "mvn spring-boot:run -Drun.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\""
+        command: "mvn spring-boot:run -Dspring-boot.run.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\""
         workdir: "${CHE_PROJECTS_ROOT}/java-jboss-fuse"
   - 
     name: 4. Log into deployment cluster


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Replaces `jvmArguments` with `-Dspring-boot.run.jvmArguments` to run jboss-fuse sample in debug mode. Spring 2.x requires this parameter.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1501

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
