### PR TITLE
For power : bumping up memory in plugin registry 

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/rhel.Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/rhel.Dockerfile
@@ -64,6 +64,7 @@ RUN ./check_plugins_location.sh v3
 RUN ./set_plugin_dates.sh v3
 RUN ./check_metas_schema.sh v3
 RUN ./swap_images.sh v3
+RUN ./bump_memory.sh v3
 RUN if [[ ${USE_DIGESTS} == "true" ]]; then ./write_image_digests.sh v3; fi
 RUN ./index.sh v3 > /build/v3/plugins/index.json
 RUN ./list_referenced_images.sh v3 > /build/v3/external_images.txt

--- a/dependencies/che-plugin-registry/build/scripts/bump_memory.sh
+++ b/dependencies/che-plugin-registry/build/scripts/bump_memory.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
+#
+# Copyright (c) 2018-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
-
 # script invoked for pluginregistry to bump memory for theia on power only - https://issues.redhat.com/browse/CRW-1475
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)

--- a/dependencies/che-plugin-registry/build/scripts/bump_memory.sh
+++ b/dependencies/che-plugin-registry/build/scripts/bump_memory.sh
@@ -13,6 +13,6 @@ metayaml=$($SCRIPT_DIR/list_yaml.sh "$YAML_ROOT"/plugins/eclipse/che-theia/next)
 
 # we bump up memory for che-theia's meta.yaml only for power 
 if [[ "$(uname -m)" == "ppc64le" ]]; then
-   sed -E -i 's|memoryLimit: "512M"|memoryLimit: "3Gi"|g' $metayaml
+   sed -E -i 's|memoryLimit: "512M"|memoryLimit: "2Gi"|g' $metayaml
 fi
 

--- a/dependencies/che-plugin-registry/build/scripts/bump_memory.sh
+++ b/dependencies/che-plugin-registry/build/scripts/bump_memory.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+
+# script invoked for pluginregistry to bump memory for theia on power only - https://issues.redhat.com/browse/CRW-1475
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+YAML_ROOT="$1"
+
+metayaml=$($SCRIPT_DIR/list_yaml.sh "$YAML_ROOT"/plugins/eclipse/che-theia/next)
+
+# we bump up memory for che-theia's meta.yaml only for power 
+if [[ "$(uname -m)" == "ppc64le" ]]; then
+   sed -E -i 's|memoryLimit: "512M"|memoryLimit: "3Gi"|g' $metayaml
+fi
+


### PR DESCRIPTION
For https://issues.redhat.com/browse/CRW-1475 bumping up theia memory in plugin registry for power

1. As per above JIRA , we needed more memory in plugin registry image for "che-plugin-registry/v3/plugins/eclipse/che-theia/next/meta.yaml"
2. Invoke new script bump_memory.sh for power in rhel.dockerfile
Signed-off-by: Amit Ghatwal <ghatwala@us.ibm.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?


### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
