### PR TITLE
fix computation for CRW_VERSION default if...

### DIFF
--- a/dependencies/che-devfile-registry/build/scripts/update_template.sh
+++ b/dependencies/che-devfile-registry/build/scripts/update_template.sh
@@ -7,24 +7,23 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
+# use this script to update the deploy/openshift/crw-*-registry.yaml file
+# script is shared with both CRW devfile and plugin registries
 
-set -e
-set -x
+registryName=devfile
 
 unset SOURCE_TEMPLATE
-unset CSV_VERSION
 unset CRW_VERSION
-
-MIDSTM_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-CRW_VERSION=${MIDSTM_BRANCH#*-}
-DOCKER_IMAGE="registry.redhat.io/codeready-workspaces/devfileregistry-rhel8"
+MIDSTM_BRANCH=$(git rev-parse --abbrev-ref HEAD || true)
+CRW_VERSION=${MIDSTM_BRANCH#crw-}; CRW_VERSION=${CRW_VERSION%-rhel*} # crw-2.y-rhel-8 ==> 2.y
+DOCKER_IMAGE="registry.redhat.io/codeready-workspaces/${registryName}registry-rhel8"
 
 usage () {
-    echo "Usage:     $0 -s SOURCE_TEMPLATE"
-    echo "Example:   $0 -s crw-devfile-registry.yaml -i ${DOCKER_IMAGE} -t 2.y"
+    echo "Usage:     $0 -s path/to/crw-${registryName}-registry.yaml"
+    echo "Example:   $0 -s deploy/openshift/crw-${registryName}-registry.yaml -i ${DOCKER_IMAGE} -t 2.y"
     echo "Options:
-    -t Codeready Workspaces version (compute from MIDSTM_BRANCH if not set)
-    -i Codeready Workspaces devfile registry image (default to ${DOCKER_IMAGE})
+    -t CodeReady Workspaces ${registryName} registry image tag (compute from MIDSTM_BRANCH if not set)
+    -i CodeReady Workspaces ${registryName} registry image (default to ${DOCKER_IMAGE})
     --help, -h            help
       "
     exit 1
@@ -34,30 +33,31 @@ while [[ "$#" -gt 0 ]]; do
   case $1 in
     '-s') SOURCE_TEMPLATE="$2"; shift 1;;
     '-t') CRW_VERSION="$2"; shift 1;; # 2.y
-    '-i') DOCKER_IMAGE="$2"; shift 1;; # 2.y
+    '-i') DOCKER_IMAGE="$2"; shift 1;; # registry.redhat.io/codeready-workspaces/*registry-rhel8
     '--help'|'-h') usage;;
   esac
   shift 1
 done
-
-DEFAULT_TAG=${CRW_VERSION%%-*}
+DEFAULT_TAG=${CRW_VERSION}
 [[ ${DEFAULT_TAG} == "2" ]] && DEFAULT_TAG="nightly"
+if [[ -z "${SOURCE_TEMPLATE}" ]] || [[ ! -w "${SOURCE_TEMPLATE}" ]]; then usage; fi
 
-if [[ -z "${SOURCE_TEMPLATE}" ]]; then usage; fi
+set -e
+set -x
 
 sed -i \
     -e "s|Eclipse Che|CodeReady Workspaces|g" \
     -e "s|CHE_|CRW_|g" \
     -e "s|che|codeready|g" \
-    -e "s|Che|Codeready|g" \
+    -e "s|Che|CodeReady|g" \
     ${SOURCE_TEMPLATE}
 
 yq -ryiY "(.parameters[] | select(.name == \"IMAGE\") | .value ) = \"${DOCKER_IMAGE}\"" ${SOURCE_TEMPLATE}
-yq -ryiY "(.parameters[] | select(.name == \"IMAGE\") | .description ) = \"CodeReady Workspaces devfile registry Docker image. Defaults to ${DOCKER_IMAGE}\"" ${SOURCE_TEMPLATE}
+yq -ryiY "(.parameters[] | select(.name == \"IMAGE\") | .description ) = \"CodeReady Workspaces ${registryName} registry container image. Defaults to ${DOCKER_IMAGE}\"" ${SOURCE_TEMPLATE}
 yq -ryiY "(.parameters[] | select(.name == \"IMAGE_TAG\") | .value ) = \"${DEFAULT_TAG}\"" ${SOURCE_TEMPLATE}
 
 echo "$(echo '#
-# Copyright (c) 2018-2021 Red Hat, Inc.
+# Copyright (c) 2018-'$(date +%Y)' Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dependencies/che-devfile-registry/deploy/openshift/crw-devfile-registry.yaml
+++ b/dependencies/che-devfile-registry/deploy/openshift/crw-devfile-registry.yaml
@@ -113,11 +113,12 @@ parameters:
   - name: IMAGE
     value: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8
     displayName: CodeReady Workspaces devfile registry image
-    description: CodeReady Workspaces devfile registry Docker image. Defaults to registry.redhat.io/codeready-workspaces/devfileregistry-rhel8
+    description: CodeReady Workspaces devfile registry container image. Defaults to
+      registry.redhat.io/codeready-workspaces/devfileregistry-rhel8
   - name: IMAGE_TAG
     value: '2.7'
     displayName: CodeReady Workspaces devfile registry version
-    description: CodeReady Workspaces devfile registry version which defaults to '2.7'
+    description: CodeReady Workspaces devfile registry version
   - name: MEMORY_LIMIT
     value: 256Mi
     displayName: Memory Limit

--- a/dependencies/che-plugin-registry/build/scripts/update_template.sh
+++ b/dependencies/che-plugin-registry/build/scripts/update_template.sh
@@ -7,24 +7,23 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
+# use this script to update the deploy/openshift/crw-*-registry.yaml file
+# script is shared with both CRW devfile and plugin registries
 
-set -e
-set -x
+registryName=plugin
 
 unset SOURCE_TEMPLATE
-unset CSV_VERSION
 unset CRW_VERSION
-
-MIDSTM_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-CRW_VERSION=${MIDSTM_BRANCH#*-}
-DOCKER_IMAGE="registry.redhat.io/codeready-workspaces/pluginregistry-rhel8"
+MIDSTM_BRANCH=$(git rev-parse --abbrev-ref HEAD || true)
+CRW_VERSION=${MIDSTM_BRANCH#crw-}; CRW_VERSION=${CRW_VERSION%-rhel*} # crw-2.y-rhel-8 ==> 2.y
+DOCKER_IMAGE="registry.redhat.io/codeready-workspaces/${registryName}registry-rhel8"
 
 usage () {
-    echo "Usage:     $0 -s SOURCE_TEMPLATE"
-    echo "Example:   $0 -s crw-plugin-registry.yaml -i ${DOCKER_IMAGE} -t 2.y"
+    echo "Usage:     $0 -s path/to/crw-${registryName}-registry.yaml"
+    echo "Example:   $0 -s deploy/openshift/crw-${registryName}-registry.yaml -i ${DOCKER_IMAGE} -t 2.y"
     echo "Options:
-    -t Codeready Workspaces version (compute from MIDSTM_BRANCH if not set)
-    -i Codeready Workspaces plugin registry image (default to ${DOCKER_IMAGE})
+    -t CodeReady Workspaces ${registryName} registry image tag (compute from MIDSTM_BRANCH if not set)
+    -i CodeReady Workspaces ${registryName} registry image (default to ${DOCKER_IMAGE})
     --help, -h            help
       "
     exit 1
@@ -34,30 +33,31 @@ while [[ "$#" -gt 0 ]]; do
   case $1 in
     '-s') SOURCE_TEMPLATE="$2"; shift 1;;
     '-t') CRW_VERSION="$2"; shift 1;; # 2.y
-    '-i') DOCKER_IMAGE="$2"; shift 1;; # 2.y
+    '-i') DOCKER_IMAGE="$2"; shift 1;; # registry.redhat.io/codeready-workspaces/*registry-rhel8
     '--help'|'-h') usage;;
   esac
   shift 1
 done
-
-DEFAULT_TAG=${CRW_VERSION%%-*}
+DEFAULT_TAG=${CRW_VERSION}
 [[ ${DEFAULT_TAG} == "2" ]] && DEFAULT_TAG="nightly"
+if [[ -z "${SOURCE_TEMPLATE}" ]] || [[ ! -w "${SOURCE_TEMPLATE}" ]]; then usage; fi
 
-if [[ -z "${SOURCE_TEMPLATE}" ]]; then usage; fi
+set -e
+set -x
 
 sed -i \
     -e "s|Eclipse Che|CodeReady Workspaces|g" \
     -e "s|CHE_|CRW_|g" \
     -e "s|che|codeready|g" \
-    -e "s|Che|Codeready|g" \
+    -e "s|Che|CodeReady|g" \
     ${SOURCE_TEMPLATE}
 
 yq -ryiY "(.parameters[] | select(.name == \"IMAGE\") | .value ) = \"${DOCKER_IMAGE}\"" ${SOURCE_TEMPLATE}
-yq -ryiY "(.parameters[] | select(.name == \"IMAGE\") | .description ) = \"CodeReady Workspaces plugin registry Docker image. Defaults to ${DOCKER_IMAGE}\"" ${SOURCE_TEMPLATE}
+yq -ryiY "(.parameters[] | select(.name == \"IMAGE\") | .description ) = \"CodeReady Workspaces ${registryName} registry container image. Defaults to ${DOCKER_IMAGE}\"" ${SOURCE_TEMPLATE}
 yq -ryiY "(.parameters[] | select(.name == \"IMAGE_TAG\") | .value ) = \"${DEFAULT_TAG}\"" ${SOURCE_TEMPLATE}
 
 echo "$(echo '#
-# Copyright (c) 2018-2021 Red Hat, Inc.
+# Copyright (c) 2018-'$(date +%Y)' Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dependencies/che-plugin-registry/deploy/openshift/crw-plugin-registry.yaml
+++ b/dependencies/che-plugin-registry/deploy/openshift/crw-plugin-registry.yaml
@@ -113,11 +113,12 @@ parameters:
   - name: IMAGE
     value: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8
     displayName: CodeReady Workspaces plugin registry image
-    description: CodeReady Workspaces plugin registry Docker image. Defaults to registry.redhat.io/codeready-workspaces/pluginregistry-rhel8
+    description: CodeReady Workspaces plugin registry container image. Defaults to
+      registry.redhat.io/codeready-workspaces/pluginregistry-rhel8
   - name: IMAGE_TAG
     value: '2.7'
     displayName: CodeReady Workspaces plugin registry version
-    description: CodeReady Workspaces plugin registry version which defaults to '2.7'
+    description: CodeReady Workspaces plugin registry version
   - name: MEMORY_LIMIT
     value: 256Mi
     displayName: Memory Limit


### PR DESCRIPTION
### What does this PR do?

fix computation for CRW_VERSION default if not set;
don't fail computing MIDSTM_BRANCH if not in a GH repo checkout folder;
fix description of -i / DOCKER_IMAGE field;
fix Codeready => CodeReady;
update examples and usage so it's obvious you need complete path to the yaml file;
remove 'which defaults to 2._' in yaml so we don't end up with 2.8 and stated default of 2.7;
replace 'Docker' with 'container';
make copyright date based on current year instead of hardcoded to 2021;
fix DEFAULT_TAG;
suppress -x echoes until after we know we have SOURCE_TEMPLATE defined;
remove CSV_VERSION var, never used;
make both scripts identical except for the registryName=plugin or devfile;
show usage if SOURCE_TEMPLATE file not writeable;
add header explaining putpise of script

Change-Id: Iea4ee9a06bb82d459cf53d4ff2294d1015092119
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.