### PR TITLE
Fixing go devfile preferences

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/05_go/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_go/devfile.yaml
@@ -17,7 +17,7 @@ components:
   memoryLimit: 512Mi
   preferences:
     go.lintTool: 'golangci-lint'
-    go.lintFlags: ['--fast']
+    go.lintFlags: '--fast'
 -
   type: dockerimage
   image: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8:2.7


### PR DESCRIPTION
### What does this PR do?
Fixing go devfile preferences according to upstream - https://github.com/eclipse/che-devfile-registry/blob/master/devfiles/go/devfile.yaml#L27

Try it on workspaces.openshift.com

[![Contribute](https://raw.githubusercontent.com/redhat-developer-demos/quarkus-reactjs-postit-app/master/factory-contribute.svg)](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/ibuziuk/codeready-workspaces/go_devfile_fixup/dependencies/che-devfile-registry/devfiles/05_go/devfile.yaml)

### What issues does this PR fix or reference?
N/A

#### Release Notes
N/A

#### Docs PR (if applicable)
N/A
