### PR TITLE
Fix debugging a quarkus app

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/03_java11-maven-quarkus/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_java11-maven-quarkus/devfile.yaml
@@ -38,6 +38,14 @@ components:
         port: 8080
         attributes:
           path: /hello/greeting/che-user
+      - name: 'debug'
+        port: 5005
+        attributes:
+          public: 'false'
+      - name: 'tests'
+        port: 8081
+        attributes:
+          public: 'false'
 commands:
   -
     name: 1. Package the application
@@ -53,7 +61,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "mvn compile quarkus:dev -Dquarkus.http.host=0.0.0.0"
+        command: "mvn compile quarkus:dev -Dquarkus.http.host=0.0.0.0 -Dquarkus.live-reload.instrumentation=false"
         workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started
   -
     name: Attach remote debugger


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
- Adds an attribute `-Dquarkus.live-reload.instrumentation=false` into run command to disable instrumentation. It is a quickfix to avoid https://github.com/quarkusio/quarkus/issues/16191
-  Marks ports 5005 and 8081 as private to avoid notifications about port listening

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1543

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

