### PR TITLE
Deprecate the asciidoctor-vscode plugin

### DIFF
--- a/dependencies/che-plugin-registry/v3/plugins/joaompinto/vscode-asciidoctor/2.7.7/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/joaompinto/vscode-asciidoctor/2.7.7/meta.yaml
@@ -10,6 +10,8 @@ icon: /v3/images/joaompinto-asciidoctor-vscode-icon.png
 category: Language
 repository: https://github.com/asciidoctor/asciidoctor-vscode
 firstPublicationDate: "2019-12-02"
+deprecate:
+  autoMigrate: false
 spec:
   extensions:
   - https://download.jboss.org/jbosstools/vscode/3rdparty/asciidoctor-vscode/asciidoctor-vscode-2.7.7.vsix


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Deprecate this plugin as it doesn't seem to have a good reason for being there, and is broken.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

Fixes [CRW-1701](https://issues.redhat.com/browse/CRW-1701)

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
