### PR TITLE
Remove global memory limits from devfile meta.yamls

### DIFF
--- a/dependencies/che-devfile-registry/build/scripts/check_mandatory_fields.sh
+++ b/dependencies/che-devfile-registry/build/scripts/check_mandatory_fields.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-FIELDS=('displayName' 'description' 'tags' 'icon' 'globalMemoryLimit')
+FIELDS=('displayName' 'description' 'tags' 'icon')
 
 readarray -d '' metas < <(find devfiles -name 'meta.yaml' -print0)
 for meta in "${metas[@]}"; do

--- a/dependencies/che-devfile-registry/devfiles/00_java11-maven-microprofile-bootable/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java11-maven-microprofile-bootable/meta.yaml
@@ -3,4 +3,3 @@ displayName: Java with JBoss EAP XP 2.0 Bootable Jar
 description: Java stack with OpenJDK 11, Maven 3.6.3 and JBoss EAP XP 2.0 Bootable Jar
 tags: ["Java", "OpenJDK", "Maven", "EAP", "Microprofile", "EAP XP", "Bootable Jar", "UBI8"]
 icon: /images/type-jboss.svg
-globalMemoryLimit: 3698Mi

--- a/dependencies/che-devfile-registry/devfiles/00_java11-maven-microprofile-xp2/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java11-maven-microprofile-xp2/meta.yaml
@@ -3,4 +3,3 @@ displayName: Java with JBoss EAP XP 2.0 Microprofile
 description: Java stack with OpenJDK 11, Maven 3.5.4 and JBoss EAP XP 2.0
 tags: ["Java", "OpenJDK", "Maven", "EAP", "Microprofile", "EAP XP", "RHEL8"]
 icon: /images/type-jboss.svg
-globalMemoryLimit: 3698Mi

--- a/dependencies/che-devfile-registry/devfiles/00_java8-maven-eap/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java8-maven-eap/meta.yaml
@@ -3,4 +3,3 @@ displayName: Java with JBoss EAP 7.3
 description: Java stack with OpenJDK 8, Maven 3.5 and JBoss EAP 7.3
 tags: ["Java", "OpenJDK", "Maven", "EAP", "RHEL7"]
 icon: /images/type-jboss.svg
-globalMemoryLimit: 3698Mi

--- a/dependencies/che-devfile-registry/devfiles/02_java8-maven-fuse/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java8-maven-fuse/meta.yaml
@@ -3,4 +3,3 @@ displayName: Red Hat Fuse
 description: Red Hat Fuse stack with OpenJDK 8 and Maven 3.6.3
 tags: ["Java", "OpenJDK", "Maven", "Red Hat Fuse", "UBI8"]
 icon: /images/type-fuse.svg
-globalMemoryLimit: 3328Mi

--- a/dependencies/che-devfile-registry/devfiles/03_camelk/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_camelk/meta.yaml
@@ -3,4 +3,3 @@ displayName: Tooling for Apache Camel K
 description: Tooling to develop Integration projects with Apache Camel K
 tags: ["Apache Camel K", "Red Hat Fuse", "Integration", "UBI8"]
 icon: /images/type-fuse.svg
-globalMemoryLimit: 2850Mi

--- a/dependencies/che-devfile-registry/devfiles/03_java11-maven-gradle/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_java11-maven-gradle/meta.yaml
@@ -3,4 +3,3 @@ displayName: Java Gradle
 description: Java stack with OpenJDK 11, Maven 3.6.3, and Gradle 6.1
 tags: ["Java", "OpenJDK", "Maven", "Gradle", "UBI8"]
 icon: /images/type-gradle.svg
-globalMemoryLimit: 2802Mi

--- a/dependencies/che-devfile-registry/devfiles/03_java11-maven-lombok/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_java11-maven-lombok/meta.yaml
@@ -3,4 +3,3 @@ displayName: Java Lombok
 description: Java stack with OpenJDK 11, Maven 3.6.3 and Lombok 1.18.18
 tags: ["Java", "OpenJDK", "Maven", "Lombok", "UBI8"]
 icon: /images/type-lombok.svg
-globalMemoryLimit: 3186Mi

--- a/dependencies/che-devfile-registry/devfiles/03_java11-maven-quarkus/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_java11-maven-quarkus/meta.yaml
@@ -3,4 +3,3 @@ displayName: Java Quarkus
 description: Java stack with OpenJDK 11, Maven 3.6.3, Gradle 6.1 and Quarkus Tools
 tags: ["Java", "OpenJDK", "Maven", "Gradle", "Quarkus", "UBI8"]
 icon: /images/type-quarkus.svg
-globalMemoryLimit: 2674Mi

--- a/dependencies/che-devfile-registry/devfiles/03_java11-maven-vertx-http-booster/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_java11-maven-vertx-http-booster/meta.yaml
@@ -3,4 +3,3 @@ displayName: Java Vert.x
 description: Java stack with OpenJDK 11, Maven 3.6.3 and Vert.x booster
 tags: ["Java", "OpenJDK", "Maven", "Vert.x", "UBI8"]
 icon: /images/type-vertx.svg
-globalMemoryLimit: 3186Mi

--- a/dependencies/che-devfile-registry/devfiles/03_java11-maven-vertx/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_java11-maven-vertx/meta.yaml
@@ -3,4 +3,3 @@ displayName: Java Maven
 description: Java stack with OpenJDK 11, Maven 3.6.3 and Vert.x demo
 tags: ["Java", "OpenJDK", "Maven", "Vert.x", "UBI8"]
 icon: /images/type-vertx.svg
-globalMemoryLimit: 3186Mi

--- a/dependencies/che-devfile-registry/devfiles/03_java8-maven-spring-boot-http-booster/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_java8-maven-spring-boot-http-booster/meta.yaml
@@ -3,4 +3,3 @@ displayName: Java Spring Boot
 description: Java stack with OpenJDK 8, Maven 3.6.3 and Spring Boot Petclinic demo application
 tags: ["Java", "OpenJDK", "Maven", "Spring Boot"]
 icon: /images/type-snowdrop.svg
-globalMemoryLimit: 3584Mi

--- a/dependencies/che-devfile-registry/devfiles/04_nodejs-configmap/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/04_nodejs-configmap/meta.yaml
@@ -3,4 +3,3 @@ displayName: NodeJS ConfigMap Express
 description: NodeJS stack with NPM 6.14.6, NodeJS 12.18.4 and ConfigMap Web Application 
 tags: ["NodeJS", "NPM", "Express", "UBI8"]
 icon: /images/type-node.svg
-globalMemoryLimit: 3816Mi

--- a/dependencies/che-devfile-registry/devfiles/04_nodejs-mongo/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/04_nodejs-mongo/meta.yaml
@@ -3,4 +3,3 @@ displayName: NodeJS MongoDB
 description: NodeJS stack with NPM 6.14.6, NodeJS 12.18.4 and MongoDB 3.6
 tags: ["NodeJS", "NPM", "Express", "MongoDB", "UBI8"]
 icon: /images/type-node.svg
-globalMemoryLimit: 2710Mi

--- a/dependencies/che-devfile-registry/devfiles/04_nodejs-simple/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/04_nodejs-simple/meta.yaml
@@ -3,4 +3,3 @@ displayName: NodeJS Express
 description: NodeJS stack with NPM 6.14.6, NodeJS 12.18.4 and Express Web Application
 tags: ["NodeJS", "NPM", "Express", "UBI8"]
 icon: /images/type-node.svg
-globalMemoryLimit: 2710Mi

--- a/dependencies/che-devfile-registry/devfiles/05_cpp/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_cpp/meta.yaml
@@ -3,4 +3,3 @@ displayName: C/C++
 description: C and C++ Developer Tools stack with GCC 8.3.1, cmake 3.11.4 and make 4.2.1 
 tags: ["C", "C++", "clang", "GCC", "g++", "make", "cmake", "UBI8"]
 icon: /images/type-cpp.svg
-globalMemoryLimit: 1686Mi

--- a/dependencies/che-devfile-registry/devfiles/05_dotnet/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_dotnet/meta.yaml
@@ -3,4 +3,3 @@ displayName: ".NET"
 description: .NET stack with .NET Core SDK 3.1.103, Runtime, C# Language Support and Debugger
 tags: [".NET", "C#", ".NET SDK", ".NET Runtime", "Netcoredbg", "Omnisharp", "UBI8"]
 icon: /images/type-dotnet.svg
-globalMemoryLimit: 2198Mi

--- a/dependencies/che-devfile-registry/devfiles/05_go/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_go/meta.yaml
@@ -3,4 +3,3 @@ displayName: Go
 description: Stack with Go 1.12.12
 tags: ["Go", "Golang", "UBI8"]
 icon: /images/type-go.svg
-globalMemoryLimit: 1686Mi

--- a/dependencies/che-devfile-registry/devfiles/05_php-cake/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_php-cake/meta.yaml
@@ -3,4 +3,3 @@ displayName: "PHP CakePHP"
 description: PHP Stack with PHP 7.3.5, Apache Web Server 2.4.37, Composer 1.8.4 and a quickstart CakePHP application for OpenShift
 tags: ["PHP", "CakePHP", "Apache", "Composer", "UBI8"]
 icon: /images/type-php.svg
-globalMemoryLimit: 2686Mi

--- a/dependencies/che-devfile-registry/devfiles/05_php-di/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_php-di/meta.yaml
@@ -3,4 +3,3 @@ displayName: "PHP-DI"
 description: PHP Stack with PHP 7.3.5, Apache Web Server 2.4.37 and Composer 1.8.4
 tags: ["PHP", "Apache", "Composer", "UBI8"]
 icon: /images/type-php.svg
-globalMemoryLimit: 2686Mi

--- a/dependencies/che-devfile-registry/devfiles/05_python/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_python/meta.yaml
@@ -3,4 +3,3 @@ displayName: Python
 description: Python Stack with Python 3.6.8 and pip 9.0.3
 tags: ["Python", "pip", "UBI8"]
 icon: /images/type-python.svg
-globalMemoryLimit: 1686Mi


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Removes redundant `globalMemoryLimit` from devfile meta.yaml as not used anymore.

Upstring PR https://github.com/eclipse-che/che-devfile-registry/pull/379

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1703
