### PR TITLE
Change sonarlint sidecar image to java8, add needed args

### DIFF
--- a/dependencies/che-plugin-registry/v3/plugins/sonarsource/sonarlint-vscode/1.20.1/meta.yaml
+++ b/dependencies/che-plugin-registry/v3/plugins/sonarsource/sonarlint-vscode/1.20.1/meta.yaml
@@ -12,11 +12,15 @@ category: Linter
 repository: https://github.com/SonarSource/sonarlint-vscode
 spec:
   containers:
-    - image: "registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.9"
+    - image: "registry.redhat.io/codeready-workspaces/plugin-java8-rhel8:2.9"
       name: vscode-sonarlint
       memoryLimit: 512Mi
       cpuLimit: 500m
       cpuRequest: 30m
+      args:
+        - sh
+        - -c
+        - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
       volumes:
         - mountPath: "/home/jboss/.m2"
           name: m2


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Fixes Sonarlint plugin. The plugin requires `node` which is not present in the `java11` image, so changed the image to `java8` which has `node`. Added missing args to the sidecar.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1604

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
