### PR TITLE
fix(plugin-registry-entrypoint): Fix image regex should support single quote, multi line and multiple occurrences

### DIFF
--- a/dependencies/che-plugin-registry/build.sh
+++ b/dependencies/che-plugin-registry/build.sh
@@ -10,6 +10,8 @@
 
 set -e
 
+base_dir=$(cd "$(dirname "$0")"; pwd)
+
 REGISTRY="quay.io"
 ORGANIZATION="crw"
 TAG="nightly"
@@ -71,6 +73,9 @@ function parse_arguments() {
 }
 
 parse_arguments "$@"
+
+echo -e "\nTest entrypoint.sh"
+EMOJI_HEADER="-" EMOJI_PASS="[PASS]" EMOJI_FAIL="[FAIL]" "${base_dir}"/build/dockerfiles/test_entrypoint.sh
 
 BUILD_COMMAND="build"
 if [[ -z $BUILDER ]]; then

--- a/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
@@ -35,7 +35,7 @@ METAS_DIR="${METAS_DIR:-${DEFAULT_METAS_DIR}}"
 #   \5 - Optional image digest identifier (empty for tags), e.g. quay.io/eclipse/che-theia(@sha256):digest
 #   \6 - Tag of image or digest, e.g. quay.io/eclipse/che-theia:(tag)
 #   \7 - Optional quotation following image reference
-IMAGE_REGEX="([[:space:]]*[\"']?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)([\"']?)"
+IMAGE_REGEX="([[:space:]>-]*[\r]?[[:space:]]*[\"']?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)([\"']?)"
 function update_container_image_references() {
 
     # We can't use the `-d` option for readarray because
@@ -48,15 +48,15 @@ function update_container_image_references() {
     # Defaults don't work because registry and tags may be different.
     if [ -n "$REGISTRY" ]; then
         echo "    Updating image registry to $REGISTRY"
-        sed -i -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" "$meta"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     if [ -n "$ORGANIZATION" ]; then
         echo "    Updating image organization to $ORGANIZATION"
-        sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" "$meta"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     if [ -n "$TAG" ]; then
         echo "    Updating image tag to $TAG"
-        sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" "$meta"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
     fi
     done
 

--- a/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
@@ -39,59 +39,59 @@ IMAGE_REGEX='([[:space:]]*"?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-
 
 function update_container_image_references() {
 
-# We can't use the `-d` option for readarray because
-# registry.centos.org/centos/httpd-24-centos7 ships with Bash 4.2
-# The below command will fail if any path contains whitespace
-readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml')
-for meta in "${metas[@]}"; do
-  echo "Checking meta $meta"
-  # Need to update each field separately in case they are not defined.
-  # Defaults don't work because registry and tags may be different.
-  if [ -n "$REGISTRY" ]; then
-    echo "    Updating image registry to $REGISTRY"
-    sed -i -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" "$meta"
-  fi
-  if [ -n "$ORGANIZATION" ]; then
-    echo "    Updating image organization to $ORGANIZATION"
-    sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" "$meta"
-  fi
-  if [ -n "$TAG" ]; then
-    echo "    Updating image tag to $TAG"
-    sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" "$meta"
-  fi
-done
+    # We can't use the `-d` option for readarray because
+    # registry.centos.org/centos/httpd-24-centos7 ships with Bash 4.2
+    # The below command will fail if any path contains whitespace
+    readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml')
+    for meta in "${metas[@]}"; do
+    echo "Checking meta $meta"
+    # Need to update each field separately in case they are not defined.
+    # Defaults don't work because registry and tags may be different.
+    if [ -n "$REGISTRY" ]; then
+        echo "    Updating image registry to $REGISTRY"
+        sed -i -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" "$meta"
+    fi
+    if [ -n "$ORGANIZATION" ]; then
+        echo "    Updating image organization to $ORGANIZATION"
+        sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" "$meta"
+    fi
+    if [ -n "$TAG" ]; then
+        echo "    Updating image tag to $TAG"
+        sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" "$meta"
+    fi
+    done
 
 }
 
 
 function run_main() {
 
-update_container_image_references
+    update_container_image_references
 
-# For testing, the images used for the che-theia, theia runtime, and machine-exec
-# plugins can be overridden via the environment variables
-#     CHE_PLUGIN_REGISTRY_THEIA_IMAGE
-#     CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE
-#     CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE
-# If set, these env vars override all modifications
-# (e.g. via CHE_DEVFILE_IMAGES_REGISTRY_URL)
-#
-if [ -n "$CHE_PLUGIN_REGISTRY_THEIA_IMAGE" ]; then
-  echo "Overriding Che Theia image with $CHE_PLUGIN_REGISTRY_THEIA_IMAGE"
-  sed -i -E "s|image:.*theia-rhel8.*|image: $CHE_PLUGIN_REGISTRY_THEIA_IMAGE|" "${metas[@]}"
-fi
+    # For testing, the images used for the che-theia, theia runtime, and machine-exec
+    # plugins can be overridden via the environment variables
+    #     CHE_PLUGIN_REGISTRY_THEIA_IMAGE
+    #     CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE
+    #     CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE
+    # If set, these env vars override all modifications
+    # (e.g. via CHE_DEVFILE_IMAGES_REGISTRY_URL)
+    #
+    if [ -n "$CHE_PLUGIN_REGISTRY_THEIA_IMAGE" ]; then
+    echo "Overriding Che Theia image with $CHE_PLUGIN_REGISTRY_THEIA_IMAGE"
+    sed -i -E "s|image:.*theia-rhel8.*|image: $CHE_PLUGIN_REGISTRY_THEIA_IMAGE|" "${metas[@]}"
+    fi
 
-if [ -n "$CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE" ]; then
-  echo "Overriding Theia remote runtime image with $CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE"
-  sed -i -E "s|image:.*theia-endpoint-rhel8.*|image: $CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE|" "${metas[@]}"
-fi
+    if [ -n "$CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE" ]; then
+    echo "Overriding Theia remote runtime image with $CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE"
+    sed -i -E "s|image:.*theia-endpoint-rhel8.*|image: $CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE|" "${metas[@]}"
+    fi
 
-if [ -n "$CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE" ]; then
-  echo "Overriding Theia remote runtime image with $CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE"
-  sed -i -E "s|image:.*machineexec-rhel8.*|image: $CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE|" "${metas[@]}"
-fi
+    if [ -n "$CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE" ]; then
+    echo "Overriding Theia remote runtime image with $CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE"
+    sed -i -E "s|image:.*machineexec-rhel8.*|image: $CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE|" "${metas[@]}"
+    fi
 
-exec "${@}"
+    exec "${@}"
 
 }
 

--- a/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
@@ -36,32 +36,6 @@ METAS_DIR="${METAS_DIR:-${DEFAULT_METAS_DIR}}"
 #   \6 - Tag of image or digest, e.g. quay.io/eclipse/che-theia:(tag)
 #   \7 - Optional quotation following image reference
 IMAGE_REGEX="([[:space:]>-]*[\r]?[[:space:]]*[\"']?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)([\"']?)"
-function update_container_image_references() {
-
-    # We can't use the `-d` option for readarray because
-    # registry.centos.org/centos/httpd-24-centos7 ships with Bash 4.2
-    # The below command will fail if any path contains whitespace
-    readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml')
-    for meta in "${metas[@]}"; do
-    echo "Checking meta $meta"
-    # Need to update each field separately in case they are not defined.
-    # Defaults don't work because registry and tags may be different.
-    if [ -n "$REGISTRY" ]; then
-        echo "    Updating image registry to $REGISTRY"
-        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
-    fi
-    if [ -n "$ORGANIZATION" ]; then
-        echo "    Updating image organization to $ORGANIZATION"
-        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
-    fi
-    if [ -n "$TAG" ]; then
-        echo "    Updating image tag to $TAG"
-        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
-    fi
-    done
-
-}
-
 
 function run_main() {
 
@@ -91,6 +65,32 @@ function run_main() {
     fi
 
     exec "${@}"
+
+}
+
+function update_container_image_references() {
+
+    # We can't use the `-d` option for readarray because
+    # registry.centos.org/centos/httpd-24-centos7 ships with Bash 4.2
+    # The below command will fail if any path contains whitespace
+    readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml')
+    for meta in "${metas[@]}"; do
+    echo "Checking meta $meta"
+    # Need to update each field separately in case they are not defined.
+    # Defaults don't work because registry and tags may be different.
+    if [ -n "$REGISTRY" ]; then
+        echo "    Updating image registry to $REGISTRY"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
+    fi
+    if [ -n "$ORGANIZATION" ]; then
+        echo "    Updating image organization to $ORGANIZATION"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
+    fi
+    if [ -n "$TAG" ]; then
+        echo "    Updating image tag to $TAG"
+        < "$meta" tr '\n' '\r' | sed -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|g" |  tr '\r' '\n' > "$meta.tmp" && cat "$meta.tmp" > "$meta" && rm "$meta.tmp"
+    fi
+    done
 
 }
 

--- a/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
@@ -37,6 +37,8 @@ METAS_DIR="${METAS_DIR:-${DEFAULT_METAS_DIR}}"
 #   \7 - Optional quotation following image reference
 IMAGE_REGEX='([[:space:]]*"?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)("?)'
 
+function update_container_image_references() {
+
 # We can't use the `-d` option for readarray because
 # registry.centos.org/centos/httpd-24-centos7 ships with Bash 4.2
 # The below command will fail if any path contains whitespace
@@ -58,6 +60,13 @@ for meta in "${metas[@]}"; do
     sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" "$meta"
   fi
 done
+
+}
+
+
+function run_main() {
+
+update_container_image_references
 
 # For testing, the images used for the che-theia, theia runtime, and machine-exec
 # plugins can be overridden via the environment variables
@@ -83,3 +92,11 @@ if [ -n "$CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE" ]; then
 fi
 
 exec "${@}"
+
+}
+
+# do not execute the main function in unit tests
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
+then
+    run_main "${@}"
+fi

--- a/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
@@ -35,8 +35,7 @@ METAS_DIR="${METAS_DIR:-${DEFAULT_METAS_DIR}}"
 #   \5 - Optional image digest identifier (empty for tags), e.g. quay.io/eclipse/che-theia(@sha256):digest
 #   \6 - Tag of image or digest, e.g. quay.io/eclipse/che-theia:(tag)
 #   \7 - Optional quotation following image reference
-IMAGE_REGEX='([[:space:]]*"?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)("?)'
-
+IMAGE_REGEX="([[:space:]]*[\"']?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)([\"']?)"
 function update_container_image_references() {
 
     # We can't use the `-d` option for readarray because

--- a/dependencies/che-plugin-registry/build/dockerfiles/test_entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/test_entrypoint.sh
@@ -1,0 +1,356 @@
+#!/bin/bash
+#
+# Copyright (c) 2018-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+METAS_DIR=$(mktemp -d)
+
+function cleanup() {
+    rm -rf  "${METAS_DIR}";
+}
+trap cleanup EXIT
+
+RED="\e[31m"
+GREEN="\e[32m"
+RESETSTYLE="\e[0m"
+BOLD="\e[1m"
+DEFAULT_EMOJI_HEADER="🏃" # could be overiden with EMOJI_HEADER="-"
+EMOJI_HEADER=${EMOJI_HEADER:-$DEFAULT_EMOJI_HEADER}
+DEFAULT_EMOJI_PASS="✔" # could be overriden with EMOJI_PASS="[PASS]"
+EMOJI_PASS=${EMOJI_PASS:-$DEFAULT_EMOJI_PASS}
+DEFAULT_EMOJI_FAIL="✘" # could be overriden with EMOJI_FAIL="[FAIL]"
+EMOJI_FAIL=${EMOJI_FAIL:-$DEFAULT_EMOJI_FAIL}
+
+function initTest() {
+    echo -e "${BOLD}\n${EMOJI_HEADER} ${1}${RESETSTYLE}"
+    rm -rf "${METAS_DIR:?}"/*
+    unset CHE_SIDECAR_CONTAINERS_REGISTRY_URL \
+          CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION \
+          CHE_SIDECAR_CONTAINERS_REGISTRY_TAG
+
+}
+
+function assertFileContentEquals() {
+    file=$1
+    expected_metayaml=$2
+
+    if [[ $(cat "${file}") == "${expected_metayaml}" ]]; then
+        echo -e "${GREEN}${EMOJI_PASS}${RESETSTYLE} Test passed!"
+    else
+        echo -e "${RED}${EMOJI_FAIL}${RESETSTYLE} Test failed!"
+        echo "Result:"
+        cat "${file}"
+        echo "Expected:"
+        echo "${expected_metayaml}"
+        exit 1
+    fi
+}
+echo -e "${BOLD}\n${EMOJI_HEADER}${EMOJI_HEADER}${EMOJI_HEADER} Running tests for entrypoint.sh: ${BASH_SOURCE[0]}${RESETSTYLE}"
+
+
+#################################################################
+initTest "Should update image registry URL. Simple quote."
+
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: 'quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d'
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: 'https://fakeregistry.io:5000/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d'
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+export CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
+
+
+#################################################################
+initTest "Should update image registry URL with CHE_SIDECAR_CONTAINERS_REGISTRY_URL. Double quote."
+
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: "quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d"
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: "https://fakeregistry.io:5000/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d"
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+export CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
+
+
+#################################################################
+initTest "Should update image registry URL with CHE_SIDECAR_CONTAINERS_REGISTRY_URL. Multiline."
+
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: >-
+        quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: >-
+        https://fakeregistry.io:5000/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+export CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
+
+
+#################################################################
+initTest "Should update image registry URL with CHE_SIDECAR_CONTAINERS_REGISTRY_URL. Multiple occurences."
+
+metayaml=$(cat <<-END
+spec:
+ containers:
+    - image: 'quay.io/eclipse/che-theia@sha256:69b7d27a9e9a4b46c2734d995456385bb0d7ab1022638d95ddaa5a5919ef43c1'
+      env:
+        - name: THEIA_PLUGINS
+          value: 'local-dir:///plugins'
+        - name: HOSTED_PLUGIN_HOSTNAME
+          value: 0.0.0.0
+        - name: HOSTED_PLUGIN_PORT
+          value: '3130'
+        - name: THEIA_HOST
+          value: 127.0.0.1
+      mountSources: true
+      memoryLimit: 512M
+      volumes:
+        - name: plugins
+          mountPath: /plugins
+        - name: theia-local
+          mountPath: /home/theia/.theia
+      name: theia-ide
+      ports:
+        - exposedPort: 3100
+        - exposedPort: 3130
+        - exposedPort: 13131
+        - exposedPort: 13132
+        - exposedPort: 13133
+    - image: 'quay.io/eclipse/che-machine-exec@sha256:98fdc3f341ed683dc0f07176729c887f2b965bade9c27d16dc0e05f9034e624c'
+      command:
+        - /go/bin/che-machine-exec
+        - '--url'
+        - '127.0.0.1:3333'
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+ containers:
+    - image: 'https://fakeregistry.io:5000/eclipse/che-theia@sha256:69b7d27a9e9a4b46c2734d995456385bb0d7ab1022638d95ddaa5a5919ef43c1'
+      env:
+        - name: THEIA_PLUGINS
+          value: 'local-dir:///plugins'
+        - name: HOSTED_PLUGIN_HOSTNAME
+          value: 0.0.0.0
+        - name: HOSTED_PLUGIN_PORT
+          value: '3130'
+        - name: THEIA_HOST
+          value: 127.0.0.1
+      mountSources: true
+      memoryLimit: 512M
+      volumes:
+        - name: plugins
+          mountPath: /plugins
+        - name: theia-local
+          mountPath: /home/theia/.theia
+      name: theia-ide
+      ports:
+        - exposedPort: 3100
+        - exposedPort: 3130
+        - exposedPort: 13131
+        - exposedPort: 13132
+        - exposedPort: 13133
+    - image: 'https://fakeregistry.io:5000/eclipse/che-machine-exec@sha256:98fdc3f341ed683dc0f07176729c887f2b965bade9c27d16dc0e05f9034e624c'
+      command:
+        - /go/bin/che-machine-exec
+        - '--url'
+        - '127.0.0.1:3333'
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+export CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
+
+#################################################################
+initTest "Should update image organization with CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION."
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: 'quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d'
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: 'quay.io/fakeorg/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d'
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+export CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION='fakeorg'
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
+
+
+#################################################################
+initTest "Should update image organization with CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION. Multiline."
+
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: >-
+        quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: >-
+        quay.io/fakeorg/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+export CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION='fakeorg'
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
+
+
+#################################################################
+initTest "Should update image tag with CHE_SIDECAR_CONTAINERS_REGISTRY_TAG."
+
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: 'quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d'
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: 'quay.io/eclipse/che-plugin-sidecar:faketag'
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+export CHE_SIDECAR_CONTAINERS_REGISTRY_TAG='faketag'
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
+
+
+#################################################################
+initTest "Should update image tag with CHE_SIDECAR_CONTAINERS_REGISTRY_TAG. Multiline."
+
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: >-
+        quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: >-
+        quay.io/eclipse/che-plugin-sidecar:faketag
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+export CHE_SIDECAR_CONTAINERS_REGISTRY_TAG='faketag'
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
+
+
+#################################################################
+initTest "Should do nothing."
+
+metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: 'name'
+      name: asciidoctor-vscode
+END
+)
+expected_metayaml=$(cat <<-END
+spec:
+  containers:
+    - image: 'name'
+      name: asciidoctor-vscode
+END
+)
+echo "$metayaml" > "${METAS_DIR}/meta.yaml"
+export CHE_SIDECAR_CONTAINERS_REGISTRY_URL='https://fakeregistry.io:5000'
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+
+update_container_image_references
+
+assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"


### PR DESCRIPTION
### What does this PR do?
1. Fix problems with image regexp:
   - single quotes not supported
   - multiline not supported
   - multiple occurence
2. Adding unit tests script

### What issues does this PR fix or reference?
Applying upstream: https://github.com/eclipse-che/che-plugin-registry/pull/937

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
