### PR TITLE
Update jboss-eap-quickstarts sample in 00_java8-maven-eap devfile

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/00_java8-maven-eap/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java8-maven-eap/devfile.yaml
@@ -6,9 +6,11 @@ projects:
   -
     name: kitchensink-example
     source:
-      location: "https://github.com/che-samples/kitchensink-example"
-      branch: master
+      location: "https://github.com/jboss-developer/jboss-eap-quickstarts.git"
+      branch: 7.3.x
+      commitId: 7ead7157d3264cbc948429ad1b19896d97ee91aa
       type: git
+      sparseCheckoutDir: kitchensink-jsp
 components:
   -
     type: chePlugin
@@ -30,6 +32,8 @@ components:
     endpoints:
       - name: 'eap'
         port: 8080
+        attributes:
+          path: /index.jsp
       - name: 'jgroups'
         port: 7600
         attributes:
@@ -42,7 +46,7 @@ commands:
   -
     name: 1. Build
     actions:
-      - workdir: '${CHE_PROJECTS_ROOT}/kitchensink-example'
+      - workdir: '${CHE_PROJECTS_ROOT}/kitchensink-example/kitchensink-jsp'
         type: exec
         command: scl enable rh-maven35 'mvn clean install'
         component: maven
@@ -64,7 +68,7 @@ commands:
         component: maven
         command: cp target/*.war /opt/eap/standalone/deployments/ROOT.war && 
           echo 'Archive was deployed, click on eap endpoint from Workspace view to open the application'
-        workdir: ${CHE_PROJECTS_ROOT}/kitchensink-example
+        workdir: ${CHE_PROJECTS_ROOT}/kitchensink-example/kitchensink-jsp
   -
     name: 4. Hot update
     actions:
@@ -72,7 +76,7 @@ commands:
         type: exec
         component: maven
         command: "scl enable rh-maven35 'mvn clean install' && sleep 2 && cp target/*.war /opt/eap/standalone/deployments/ROOT.war"
-        workdir: ${CHE_PROJECTS_ROOT}/kitchensink-example
+        workdir: ${CHE_PROJECTS_ROOT}/kitchensink-example/kitchensink-jsp
   -
     name: Debug (Attach)
     actions:


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Switch to https://github.com/jboss-developer/jboss-eap-quickstarts/tree/EAP_7.3.0.GA/kitchensink-jsp instead of https://github.com/che-samples/kitchensink-example from master branch (which appears to be based on EAP 7.2.0, from 2019)

![screenshot-codeready-codeready-workspaces-operator apps che-dev x6e0 p1 openshiftapps com-2021 05 27-12_05_05](https://user-images.githubusercontent.com/1271546/119835247-56fd8c00-bf09-11eb-9e02-7c54ce84f603.png)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1709

<!-- #### Changelog -->
N/A


#### Release Notes
N/A

#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
