### PR TITLE
chore(plugin-registry-generator): adding new option to be used in dev mode to use public images instead of unreleased crw images

### DIFF
--- a/dependencies/che-plugin-registry/build.sh
+++ b/dependencies/che-plugin-registry/build.sh
@@ -72,6 +72,10 @@ function parse_arguments() {
             BUILD_FLAGS_ARRAY+=("--skip-digest-generation:true")
             shift;
             ;;
+            --use-dev-images)
+            BUILD_FLAGS_ARRAY+=("--use-dev-images:true")
+            shift;
+            ;;
             *)
             print_usage
             exit 0

--- a/dependencies/che-plugin-registry/tools/build/src/inversify-binding.ts
+++ b/dependencies/che-plugin-registry/tools/build/src/inversify-binding.ts
@@ -39,6 +39,7 @@ export class InversifyBinding {
 
     let embedVsix = false;
     let skipDigestGeneration = false;
+    let useDevImages = false;
 
     const args = process.argv.slice(2);
     args.forEach(arg => {
@@ -50,6 +51,9 @@ export class InversifyBinding {
       }
       if (arg.startsWith('--skip-digest-generation:')) {
         skipDigestGeneration = 'true' === arg.substring('--skip-digest-generation:'.length);
+      }
+      if (arg.startsWith('--use-dev-images:')) {
+        useDevImages = 'true' === arg.substring('--use-dev-images:'.length);
       }
     });
     this.container = new Container();
@@ -80,6 +84,8 @@ export class InversifyBinding {
     this.container.bind('boolean').toConstantValue(embedVsix).whenTargetNamed('EMBED_VSIX');
 
     this.container.bind('boolean').toConstantValue(skipDigestGeneration).whenTargetNamed('SKIP_DIGEST_GENERATION');
+
+    this.container.bind('boolean').toConstantValue(useDevImages).whenTargetNamed('USE_DEV_IMAGES');
 
     await fs.mkdirs(unpackedDirectory);
     await fs.mkdirs(downloadDirectory);

--- a/dependencies/che-plugin-registry/tools/build/src/meta-yaml/dev-images-helper.ts
+++ b/dependencies/che-plugin-registry/tools/build/src/meta-yaml/dev-images-helper.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+
+import { MetaYamlPluginInfo } from './meta-yaml-plugin-info';
+
+/**
+ * Update all reference to images to use dev prefix to use dev images instead of production images that may not be available yet.
+ * For instance, CodeReady Workspaces is using prefix `registry.redhat.io/codeready-workspaces` but for developers it would be `quay.io/crw`
+ */
+@injectable()
+export class DevImagesHelper {
+
+  async replaceImagePrefix(metaYamlPluginInfos: MetaYamlPluginInfo[], prodImagePrefix: string, devImagePrefix: string): Promise<MetaYamlPluginInfo[]> {
+    return Promise.all(
+      metaYamlPluginInfos.map(async plugin => {
+        const spec = plugin.spec;
+        if (spec) {
+          if (spec.containers) {
+            await Promise.all(
+              spec.containers.map(
+                async container => (container.image = container.image.replace(prodImagePrefix, devImagePrefix))
+              )
+            );
+          }
+          if (spec.initContainers) {
+            await Promise.all(
+              spec.initContainers.map(
+                async container => (container.image = container.image.replace(prodImagePrefix, devImagePrefix))
+              )
+            );
+          }
+        }
+        return plugin;
+      })
+    );
+  }
+}

--- a/dependencies/che-plugin-registry/tools/build/src/meta-yaml/meta-yaml-module.ts
+++ b/dependencies/che-plugin-registry/tools/build/src/meta-yaml/meta-yaml-module.ts
@@ -10,12 +10,15 @@
 import { ContainerModule, interfaces } from 'inversify';
 
 import { DigestImagesHelper } from './digest-images-helper';
+import { DevImagesHelper } from './dev-images-helper';
 import { ExternalImagesWriter } from './external-images-writer';
 import { IndexWriter } from './index-writer';
 import { MetaYamlWriter } from './meta-yaml-writer';
 
 const metaYamlModule = new ContainerModule((bind: interfaces.Bind) => {
   bind(DigestImagesHelper).toSelf().inSingletonScope();
+  bind(DevImagesHelper).toSelf().inSingletonScope();
+
   bind(ExternalImagesWriter).toSelf().inSingletonScope();
   bind(IndexWriter).toSelf().inSingletonScope();
   bind(MetaYamlWriter).toSelf().inSingletonScope();

--- a/dependencies/che-plugin-registry/tools/build/tests/build.spec.ts
+++ b/dependencies/che-plugin-registry/tools/build/tests/build.spec.ts
@@ -28,6 +28,7 @@ import { CheTheiaPluginsYamlWriter } from '../src/che-theia-plugin/che-theia-plu
 import { Container } from 'inversify';
 import { Deferred } from '../src/util/deferred';
 import { DigestImagesHelper } from '../src/meta-yaml/digest-images-helper';
+import { DevImagesHelper } from '../src/meta-yaml/dev-images-helper';
 import { ExternalImagesWriter } from '../src/meta-yaml/external-images-writer';
 import { FeaturedAnalyzer } from '../src/featured/featured-analyzer';
 import { FeaturedWriter } from '../src/featured/featured-writer';
@@ -92,6 +93,11 @@ describe('Test Build', () => {
   const digestImagesHelperUpdateImagesMock = jest.fn();
   const digestImagesHelper: any = {
     updateImages: digestImagesHelperUpdateImagesMock,
+  };
+
+  const devImagesHelperReplaceImagePrefixMock = jest.fn();
+  const devImagesHelper: any = {
+    replaceImagePrefix: devImagesHelperReplaceImagePrefixMock,
   };
 
   const recommendationsAnalyzerGenerateMock = jest.fn();
@@ -217,6 +223,7 @@ describe('Test Build', () => {
     container.bind('string').toConstantValue('/fake-root-directory').whenTargetNamed('PLUGIN_REGISTRY_ROOT_DIRECTORY');
     container.bind('string').toConstantValue('/fake-root-directory/output').whenTargetNamed('OUTPUT_ROOT_DIRECTORY');
     container.bind('boolean').toConstantValue(false).whenTargetNamed('SKIP_DIGEST_GENERATION');
+    container.bind('boolean').toConstantValue(false).whenTargetNamed('USE_DEV_IMAGES');
     container.bind('string[]').toConstantValue([]).whenTargetNamed('ARGUMENTS');
     container.bind(FeaturedAnalyzer).toConstantValue(featuredAnalyzer);
     container.bind(FeaturedWriter).toConstantValue(featuredWriter);
@@ -236,6 +243,7 @@ describe('Test Build', () => {
     container.bind(ExternalImagesWriter).toConstantValue(externalImagesWriter);
     container.bind(IndexWriter).toConstantValue(indexWriter);
     container.bind(DigestImagesHelper).toConstantValue(digestImagesHelper);
+    container.bind(DevImagesHelper).toConstantValue(devImagesHelper);
 
     container.bind(Build).toSelf().inSingletonScope();
     build = container.get(Build);
@@ -511,6 +519,7 @@ describe('Test Build', () => {
 
   test('basics with skip Digests', async () => {
     container.rebind('boolean').toConstantValue(true).whenTargetNamed('SKIP_DIGEST_GENERATION');
+    container.bind('boolean').toConstantValue(false).whenTargetNamed('USE_DEV_IMAGES');
     // force to refresh the singleton
     container.rebind(Build).toSelf().inSingletonScope();
     build = container.get(Build);

--- a/dependencies/che-plugin-registry/tools/build/tests/inversify-binding.spec.ts
+++ b/dependencies/che-plugin-registry/tools/build/tests/inversify-binding.spec.ts
@@ -20,6 +20,7 @@ import { CheTheiaPluginsAnalyzer } from '../src/che-theia-plugin/che-theia-plugi
 import { CheTheiaPluginsMetaYamlGenerator } from '../src/che-theia-plugin/che-theia-plugins-meta-yaml-generator';
 import { Container } from 'inversify';
 import { DigestImagesHelper } from '../src/meta-yaml/digest-images-helper';
+import { DevImagesHelper } from '../src/meta-yaml/dev-images-helper';
 import { ExternalImagesWriter } from '../src/meta-yaml/external-images-writer';
 import { FeaturedAnalyzer } from '../src/featured/featured-analyzer';
 import { FeaturedWriter } from '../src/featured/featured-writer';
@@ -76,6 +77,7 @@ describe('Test InversifyBinding', () => {
 
     // check meta module
     expect(container.get(DigestImagesHelper)).toBeDefined();
+    expect(container.get(DevImagesHelper)).toBeDefined();
     expect(container.get(IndexWriter)).toBeDefined();
     expect(container.get(MetaYamlWriter)).toBeDefined();
     expect(container.get(ExternalImagesWriter)).toBeDefined();
@@ -98,15 +100,18 @@ describe('Test InversifyBinding', () => {
     mockedArgv.push('--foo-arg:bar');
     mockedArgv.push('--embed-vsix:true');
     mockedArgv.push('--skip-digest-generation:true');
+    mockedArgv.push('--use-dev-images:true');
     const inversifyBinding = new InversifyBinding();
     const container: Container = await inversifyBinding.initBindings();
 
     const outputDir = container.getNamed('string', 'OUTPUT_ROOT_DIRECTORY');
     const embedded = container.getNamed('boolean', 'EMBED_VSIX');
     const skipDigests = container.getNamed('boolean', 'SKIP_DIGEST_GENERATION');
+    const useDevImage = container.getNamed('boolean', 'USE_DEV_IMAGES');
 
     expect(outputDir).toEqual(myCustomOutputDir);
     expect(embedded).toBeTruthy();
     expect(skipDigests).toBeTruthy();
+    expect(useDevImage).toBeTruthy();
   });
 });

--- a/dependencies/che-plugin-registry/tools/build/tests/meta-yaml/dev-images-helper.spec.ts
+++ b/dependencies/che-plugin-registry/tools/build/tests/meta-yaml/dev-images-helper.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { DevImagesHelper } from '../../src/meta-yaml/dev-images-helper';
+import { MetaYamlPluginInfo } from '../../src/meta-yaml/meta-yaml-plugin-info';
+
+describe('Test DevImagesHelper', () => {
+  let container: Container;
+
+  let metaYamlPlugins: MetaYamlPluginInfo[];
+  let devImagesHelper: DevImagesHelper;
+
+  beforeEach(() => {
+    metaYamlPlugins = [
+      {
+        spec: {
+          containers: [{ image: 'registry.redhat.io/codeready-workspaces/container-image1:foo' }, { image: 'quay.io/crw/container-image2:bar' }],
+          initContainers: [{ image: 'init-container-image1:foo' }, { image: 'registry.redhat.io/codeready-workspaces/init-container-image2:bar' }],
+        },
+      } as any,
+      {
+        spec: {
+          containers: [{ image: 'registry.redhat.io/openshift/container-image1:foo' }, { image: 'quay.io/codeready-workspaces/container-image2:bar' }],
+          initContainers: [{ image: 'registry.redhat.io/codeready-workspaces/init-container-image1:foo' }, { image: 'registry.redhat.io/openshift/init-container-image2:bar' }],
+        },
+      } as any,
+    ];
+
+    container = new Container();
+
+    container.bind(DevImagesHelper).toSelf().inSingletonScope();
+    devImagesHelper = container.get(DevImagesHelper);
+  });
+
+  test('basics', async () => {
+
+
+    const updatedYamls = await devImagesHelper.replaceImagePrefix(metaYamlPlugins, 'registry.redhat.io/codeready-workspaces', 'quay.io/crw');
+    const firstYaml = updatedYamls[0];
+    expect((firstYaml.spec.containers as any)[0].image).toBe('quay.io/crw/container-image1:foo');
+    expect((firstYaml.spec.containers as any)[1].image).toBe('quay.io/crw/container-image2:bar');
+    expect((firstYaml.spec.initContainers as any)[0].image).toBe('init-container-image1:foo');
+    expect((firstYaml.spec.initContainers as any)[1].image).toBe('quay.io/crw/init-container-image2:bar');
+    const secondYaml = updatedYamls[1];
+    expect((secondYaml.spec.containers as any)[0].image).toBe('registry.redhat.io/openshift/container-image1:foo');
+    expect((secondYaml.spec.containers as any)[1].image).toBe('quay.io/codeready-workspaces/container-image2:bar');
+    expect((secondYaml.spec.initContainers as any)[0].image).toBe('quay.io/crw/init-container-image1:foo');
+    expect((secondYaml.spec.initContainers as any)[1].image).toBe('registry.redhat.io/openshift/init-container-image2:bar');
+  });
+});


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Allow the option --use-dev-images to be used to replace image prefixed with registry.redhat.io/codeready-workspaces with quay.io/crw

Developers could use this command to build: 
```
BUILDER=docker SKIP_TEST=true SKIP_FORMAT=true SKIP_LINT=true  ./build.sh --skip-oci-image --use-dev-images
```
and safely try their plugin registry.

An example of a registry built with that command:
https://sunix-crw-plugin-registry-dev-h9894.surge.sh/v3/plugins/

![Selection_383](https://user-images.githubusercontent.com/650571/120775489-87ee4a00-c523-11eb-9aaf-302db21e4729.png)

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
