### PR TITLE
fix(java): remap redhat/java to redhat/java11

### DIFF
--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -284,10 +284,12 @@ plugins:
         - -c
         - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
     extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix
-  - id: redhat/java11
+  - id: redhat/java
     repository:
       url: 'https://github.com/redhat-developer/vscode-java'
       revision: v0.69.0
+    aliases:
+      - redhat/java11
     featured: true
     preferences:
       java.server.launchMode: Standard
@@ -313,12 +315,10 @@ plugins:
     metaYaml:
       extraDependencies:
         - vscjava/vscode-java-debug
-  - id: redhat/java
+  - id: redhat/java8
     repository:
       url: 'https://github.com/redhat-developer/vscode-java'
       revision: v0.63.0
-    aliases:
-      - redhat/java8
     preferences:
       java.server.launchMode: Standard
     sidecar:


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Remaps the `redhat/java` plugin to `redhat/java11`. Previously it was mapped to `redhat/java8`.

### What issues does this PR fix or reference?
Fixes CRW-1892
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
See the JIRA issue for this ticket.

#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
