### PR TITLE
fix: plugin registry digest writing and v3/plugins/.htaccess copy

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -48,13 +48,14 @@ RUN /tmp/rhel.install.sh && rm -f /tmp/rhel.install.sh
 COPY ./build/scripts/*.sh /build/
 COPY che-*.yaml /build/
 COPY resources.tgz /build/
+COPY ./v3/plugins/.htaccess /build/v3/plugins/.htaccess
 WORKDIR /build/
 
 RUN tar -xvf resources.tgz -C ./
 RUN ./swap_images.sh ./
-RUN ./swap_plugins_memory.sh output/v3
-RUN if [[ ${USE_DIGESTS} == "true" ]]; then ./write_image_digests.sh output/v3; fi
-RUN ./list_referenced_images.sh ./ > /build/output/v3/external_images.txt
+RUN ./swap_plugins_memory.sh ./output/v3
+RUN if [[ ${USE_DIGESTS} == "true" ]]; then ./write_image_digests.sh ./output/v3; fi
+RUN ./list_referenced_images.sh ./output/v3 > /build/output/v3/external_images.txt && cat /build/output/v3/external_images.txt
 RUN chmod -R g+rwX /build
 
 # Build registry, copying meta.yamls and index.json from builder
@@ -84,8 +85,8 @@ WORKDIR /var/www/html
 
 RUN mkdir -m 777 /var/www/html/v3
 COPY README.md .htaccess /var/www/html/
-COPY /v3/plugins/.htaccess /var/www/html/v3/plugins/
 COPY --from=builder /build/output/v3 /var/www/html/v3
+COPY --from=builder /build/v3/plugins/.htaccess /var/www/html/v3/plugins/
 COPY ./build/dockerfiles/rhel.entrypoint.sh ./build/dockerfiles/entrypoint.sh /usr/local/bin/
 RUN chmod g+rwX /usr/local/bin/entrypoint.sh /usr/local/bin/rhel.entrypoint.sh && \
     chgrp -R 0 /var/www/html && chmod -R g+rw /var/www/html

--- a/dependencies/che-plugin-registry/build/scripts/list_referenced_images.sh
+++ b/dependencies/che-plugin-registry/build/scripts/list_referenced_images.sh
@@ -16,7 +16,7 @@ CONTAINERS=""
 
 while IFS= read -r -d '' file; do
   CONTAINERS="${CONTAINERS} $(yq -r '..|.image?' "${file}" | grep -v "null" | sort | uniq)"
-done < <(find "$1" -maxdepth 1 -name 'che-*.yaml' -print0)
+done < <(find "$1" -name 'meta.yaml' -print0)
 
 CONTAINERS_UNIQ=()
 # shellcheck disable=SC2199


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Only read generated meta.yaml files instead of che-*.yaml files, and change COPY instruction for `.htaccess` file.

### What issues does this PR fix or reference?
CRW-1886 and CRW-1898
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
