### PR TITLE
fix(sed): update logic in write_image_digests.sh to handle single quotes

### DIFF
--- a/dependencies/che-plugin-registry/build/scripts/write_image_digests.sh
+++ b/dependencies/che-plugin-registry/build/scripts/write_image_digests.sh
@@ -56,7 +56,7 @@ for image_url in $("$SCRIPT_DIR"/list_referenced_images.sh "$YAML_ROOT") ; do
     else
       # Rewrite image to use sha-256 digests
       digest_image="${image_url%:*}@${digest}"
-      sed -i -E 's|"?'"${image_url}"'"?|"'"${digest_image}"'" # tag: '"${image_url}"'|g' "$yaml_file"
+      sed -i -E 's|'\''?'"${image_url}"''\''?|'\'''"${digest_image}"''\'' # tag: '"${image_url}"'|g' "$yaml_file"
        echo "[INFO] Update $yaml_file with $digest_image"
     fi
   done


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Handle single quotes which are now present in all the image references.

### What issues does this PR fix or reference?
CRW-1901
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
