### PR TITLE
[CRW-1912] Ensure login to registries

### DIFF
--- a/product/util.groovy
+++ b/product/util.groovy
@@ -645,6 +645,7 @@ def bootstrap(String CRW_KEYTAB, boolean force=false) {
     // also install commonly needed tools
     installSkopeoFromContainer("")
     installYq()
+    loginToRegistries()
     sh('''#!/bin/bash -xe
 # bootstrapping: if keytab is lost, upload to
 # https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/credentials/store/system/domain/_/


### PR DESCRIPTION
To fix - https://issues.redhat.com/browse/CRW-1912 by adding a call to loginToRegistries() inside the util.bootstrap() method.

Signed-off-by: Amit Ghatwal <ghatwala@us.ibm.com>

