### PR TITLE
fix(scripts): make image scripts work both pre and post meta.yaml generation

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -53,10 +53,10 @@ COPY ./v3/images/default.png /build/v3/images/
 WORKDIR /build/
 
 RUN tar -xvf resources.tgz -C ./
-RUN ./swap_images.sh ./
+RUN ./swap_images.sh ./output/v3 --use-generated-content
 RUN ./swap_plugins_memory.sh ./output/v3
 RUN if [[ ${USE_DIGESTS} == "true" ]]; then ./write_image_digests.sh ./output/v3; fi
-RUN ./list_referenced_images.sh ./output/v3 > /build/output/v3/external_images.txt && cat /build/output/v3/external_images.txt
+RUN ./list_referenced_images.sh ./output/v3 --use-generated-content > /build/output/v3/external_images.txt && cat /build/output/v3/external_images.txt
 RUN chmod -R g+rwX /build
 
 # Build registry, copying meta.yamls and index.json from builder

--- a/dependencies/che-plugin-registry/build/scripts/list_referenced_images.sh
+++ b/dependencies/che-plugin-registry/build/scripts/list_referenced_images.sh
@@ -14,9 +14,15 @@ set -e
 
 CONTAINERS=""
 
-while IFS= read -r -d '' file; do
-  CONTAINERS="${CONTAINERS} $(yq -r '..|.image?' "${file}" | grep -v "null" | sort | uniq)"
-done < <(find "$1" -name 'meta.yaml' -print0)
+if [[ $2 == "--use-generated-content" ]]; then
+  while IFS= read -r -d '' file; do
+    CONTAINERS="${CONTAINERS} $(yq -r '..|.image?' "${file}" | grep -v "null" | sort | uniq)"
+  done < <(find "$1" -name meta.yaml -print0)
+else
+  while IFS= read -r -d '' file; do
+    CONTAINERS="${CONTAINERS} $(yq -r '..|.image?' "${file}" | grep -v "null" | sort | uniq)"
+  done < <(find "$1" -maxdepth 1 -name 'che-*.yaml' -print0)
+fi
 
 CONTAINERS_UNIQ=()
 # shellcheck disable=SC2199

--- a/dependencies/che-plugin-registry/build/scripts/swap_images.sh
+++ b/dependencies/che-plugin-registry/build/scripts/swap_images.sh
@@ -12,7 +12,11 @@
 SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
 YAML_ROOT="$1"
 
-cheYamls=$("$SCRIPT_DIR"/list_che_yaml.sh "$YAML_ROOT")
+if [[ $3 == "--use-generated-content" || $2 == "--use-generated-content" ]]; then
+    cheYamls=$("$SCRIPT_DIR"/list_yaml.sh "$YAML_ROOT")
+else
+    cheYamls=$("$SCRIPT_DIR"/list_che_yaml.sh "$YAML_ROOT")
+fi
 
 # Note: optional -f flag will force this transformation even on an incompatible architecture,
 # so we can call this script from crw-operator/build/scripts/insert-related-images-to-csv.sh

--- a/dependencies/che-plugin-registry/build/scripts/write_image_digests.sh
+++ b/dependencies/che-plugin-registry/build/scripts/write_image_digests.sh
@@ -45,12 +45,11 @@ function handle_error() {
     mv "$f" "$f.removed"
   done
 }
-
-for image_url in $("$SCRIPT_DIR"/list_referenced_images.sh "$YAML_ROOT") ; do
+for image_url in $("$SCRIPT_DIR"/list_referenced_images.sh "$YAML_ROOT" --use-generated-content) ; do
   digest=$("$SCRIPT_DIR"/find_image.sh "$image_url" $ARCH  2> "$LOG_FILE" | jq -r '.Digest')
   # shellcheck disable=SC2143
   for yaml_file in $("$SCRIPT_DIR"/list_yaml.sh "$YAML_ROOT") ; do
-    [[ -z "$("$SCRIPT_DIR"/list_referenced_images.sh "$yaml_file" | grep "$image_url")" ]] && continue 
+    [[ -z "$("$SCRIPT_DIR"/list_referenced_images.sh "$yaml_file" --use-generated-content | grep "$image_url")" ]] && continue
     if [[ -z "$digest" ]] ; then
       handle_error "$yaml_file" "$image_url"
     else


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds `--use-generated-content` argument to both `list_referenced_images.sh` and  `swap_images.sh`. Do not check generated content by default so that scripts called outside of the plugin registry build process will still work.


### What issues does this PR fix or reference?
Fixes CRW-1916
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
