### PR TITLE
fix(java): make java8 plugin executable

### DIFF
--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -346,6 +346,10 @@ plugins:
       memoryLimit: 1500Mi
       cpuLimit: 500m
       cpuRequest: 30m
+      args:
+        - sh
+        - -c
+        - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
       volumeMounts:
         - name: m2
           path: /home/jboss/.m2


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Add a command to run executable endpoint for redhat/java8 plugin

https://issues.redhat.com/browse/CRW-1923
