### PR TITLE
feat: Introduce devfile v2 for quarkus getting started

### DIFF
--- a/dependencies/che-devfile-registry/build/scripts/index.sh
+++ b/dependencies/che-devfile-registry/build/scripts/index.sh
@@ -15,6 +15,10 @@ for meta in "${metas[@]}"; do
     META_DIR=$(dirname "${meta}")
     # Workaround to include self-links, since it's not possible to
     # get filename in yq easily
-    echo -e "links:\n  self: /${META_DIR}/devfile.yaml" >> "${meta}"
+    # Extra links may already be there, so just update with self link
+
+    # Ignore double quotes warning for yq expression
+    # shellcheck disable=SC2016,SC2094
+    cat <<< "$(yq --arg metadir "${META_DIR}" '.links |= . + {self: "/\($metadir)/devfile.yaml" }' "${meta}")"  > "${meta}"
 done
 yq -s 'map(.)' "${metas[@]}"

--- a/dependencies/che-devfile-registry/devfiles/03_java11-maven-quarkus/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_java11-maven-quarkus/meta.yaml
@@ -3,3 +3,5 @@ displayName: Java Quarkus
 description: Java stack with OpenJDK 11, Maven 3.6.3, Gradle 6.1 and Quarkus Tools
 tags: ["Java", "OpenJDK", "Maven", "Gradle", "Quarkus", "UBI8"]
 icon: /images/type-quarkus.svg
+links:
+  v2: https://github.com/crw-samples/quarkus-quickstarts/tree/devfilev2


### PR DESCRIPTION
### What does this PR do?
Now that it's possible to use DevWorkspaces, Getting started should show Devfile v2

needs to be backported to 2.10.x branch

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19341

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

![image](https://user-images.githubusercontent.com/436777/122584337-8875fd00-d05a-11eb-9f9e-722af1855836.png)


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
