### PR TITLE
fix(digests) do not rename .yaml files to .yaml.removed

### DIFF
--- a/dependencies/che-devfile-registry/build/scripts/write_image_digests.sh
+++ b/dependencies/che-devfile-registry/build/scripts/write_image_digests.sh
@@ -35,9 +35,12 @@ function handle_error() {
     # CRW-1941 don't fail if can't resolve digest in the registry
     # exit 1
   fi
-  for f in $(ls `dirname $yaml_file`/*.yaml) ; do
-    mv "$f" "$f.removed"
-  done
+  # CRW-1941 don't fail if can't resolve digest in the registry
+  # When uncommenting, the following shellcheck errors need to be ignored:
+  # SC2045, SC2046, SC2006, and SC2086
+  # for f in $(ls `dirname $yaml_file`/*.yaml) ; do
+  #   mv "$f" "$f.removed"
+  # done
 }
 
 for image_url in $($SCRIPT_DIR/list_referenced_images.sh "$YAML_ROOT") ; do

--- a/dependencies/che-plugin-registry/build/scripts/write_image_digests.sh
+++ b/dependencies/che-plugin-registry/build/scripts/write_image_digests.sh
@@ -38,13 +38,12 @@ function handle_error() {
     # CRW-1941 don't fail if can't resolve digest in the registry
     # exit 1
   fi
-  # shellcheck disable=SC2045
-  # shellcheck disable=SC2046
-  # shellcheck disable=SC2006
-  # shellcheck disable=SC2086
-  for f in $(ls `dirname $yaml_file`/*.yaml) ; do
-    mv "$f" "$f.removed"
-  done
+  # CRW-1941 don't fail if can't resolve digest in the registry
+  # When uncommenting, the following shellcheck errors need to be ignored:
+  # SC2045, SC2046, SC2006, and SC2086
+  # for f in $(ls `dirname $yaml_file`/*.yaml) ; do
+  #   mv "$f" "$f.removed"
+  # done
 }
 for image_url in $("$SCRIPT_DIR"/list_referenced_images.sh "$YAML_ROOT" --use-generated-content) ; do
   digest=$("$SCRIPT_DIR"/find_image.sh "$image_url" $ARCH  2> "$LOG_FILE" | jq -r '.Digest')


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
A failure in digest generation leads to all meta.yaml files in the registry being named *.yaml.removed. Let's not do this.


### What issues does this PR fix or reference?
Part of CRW-1941
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
