### PR TITLE
fix(sonarlint): use java8 image for sonarlint plugin

### DIFF
--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -434,7 +434,7 @@ plugins:
       url: 'https://github.com/SonarSource/sonarlint-vscode'
       revision: 1.20.1
     sidecar:
-      image: "registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.9"
+      image: "registry.redhat.io/codeready-workspaces/plugin-java8-rhel8:2.9"
       name: vscode-sonarlint
       memoryLimit: 512Mi
       cpuLimit: 500m


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Use java8 image which contains node to fix problems with SonarLint plugin initialization 

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1604


