### PR TITLE
chore: downgrade vscode-apache-camel to 0.0.31

### DIFF
--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -367,7 +367,7 @@ plugins:
         - sh
         - -c
         - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-apache-camel/vscode-apache-camel-0.0.32-205.vsix
+    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-apache-camel/vscode-apache-camel-0.0.31-143.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-xml'
       revision: 0.14.0

--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -356,7 +356,7 @@ plugins:
     extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-php-debug/php-debug-1.13.0.vsix
   - repository:
       url: 'https://github.com/camel-tooling/camel-lsp-client-vscode'
-      revision: 0.0.32
+      revision: 0.0.31
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.9"
       name: vscode-apache-camel


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Downgrade vscode-apache-camel extension to 0.0.31 since 0.0.32 cannot be initialized if VS Code API is 1.50.0

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1951