### PR TITLE
fix: skip vscode-commons in vscode-apache-camel

### DIFF
--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -368,6 +368,9 @@ plugins:
         - -c
         - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
     extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-apache-camel/vscode-apache-camel-0.0.31-143.vsix
+    metaYaml:
+      skipDependencies:
+        - redhat/vscode-commons
   - repository:
       url: 'https://github.com/redhat-developer/vscode-xml'
       revision: 0.14.0


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Skips dependency of vscode-commons extension in vscode-apache-camel extension to avoid such error:
```
Activating extension 'Tooling for Apache Camel K by Red Hat' failed: Dependent extension 'redhat.vscode-commons' is not installed.
```

![screenshot-codeready-vsvydenko-crw apps ocp46 crw-qe com-2021 06 25-17_15_50](https://user-images.githubusercontent.com/1271546/123438183-1c0a7900-d5d9-11eb-95a9-7d2f62aa7e14.png)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1951