### PR TITLE
fix(secrets): use single quotes for secrets

### DIFF
--- a/product/util.groovy
+++ b/product/util.groovy
@@ -447,8 +447,8 @@ def cloneRepoPoll(String URL, String REPO_PATH, String BRANCH, boolean withPolli
   if (URL.indexOf("pkgs.devel.redhat.com") == -1) {
     // remove http(s) prefix, then trim any token@ prefix too
     URL=URL - ~/http(s*):\/\// - ~/.*@/
-    def AUTH_URL_SHELL="https://\$GITHUB_TOKEN:x-oauth-basic@" + URL
-    def AUTH_URL_GROOVY="https://$GITHUB_TOKEN:x-oauth-basic@" + URL
+    def AUTH_URL_SHELL='https://\$GITHUB_TOKEN:x-oauth-basic@' + URL
+    def AUTH_URL_GROOVY='https://$GITHUB_TOKEN:x-oauth-basic@' + URL
     if (!fileExists(REPO_PATH) || withPolling) {
       // clean before checkout
       sh('''rm -fr ${WORKSPACE}/''' + REPO_PATH)
@@ -505,8 +505,8 @@ def cloneRepo(String URL, String REPO_PATH, String BRANCH) {
   if (URL.indexOf("pkgs.devel.redhat.com") == -1) {
     // remove http(s) prefix, then trim any token@ prefix too
     URL=URL - ~/http(s*):\/\// - ~/.*@/
-    def AUTH_URL_SHELL="https://\$GITHUB_TOKEN:x-oauth-basic@" + URL
-    def AUTH_URL_GROOVY="https://$GITHUB_TOKEN:x-oauth-basic@" + URL
+    def AUTH_URL_SHELL='https://\$GITHUB_TOKEN:x-oauth-basic@' + URL
+    def AUTH_URL_GROOVY='https://$GITHUB_TOKEN:x-oauth-basic@' + URL
     if (!fileExists(REPO_PATH)) {
       checkout([$class: 'GitSCM',
         branches: [[name: BRANCH]],


### PR DESCRIPTION
Change-Id: I69bbce46bb95f9da8dc482c975e411bad65afd64
Signed-off-by: nickboldt <nboldt@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Restoring the changes from https://github.com/redhat-developer/codeready-workspaces/pull/465 that I accidentally wiped out while pushing the `crw-2-rhel-8` branch

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
