### PR TITLE
feat: eclipse/che#18831 - Add option for updateBaseImages.sh to enforce PR creation

### DIFF
--- a/product/updateBaseImages.sh
+++ b/product/updateBaseImages.sh
@@ -48,7 +48,7 @@ PR_BRANCH="pr-update-base-images-$(date +%s)"
 OPENBROWSERFLAG="" # if a PR is generated, open it in a browser
 docommit=1 # by default DO commit the change
 dopush=1 # by default DO push the change
-dopronly=0 # by default DO NOT enforce pushing only through PR branches
+dopronly=0 # by default, attempt to push directly; create a PR only if necessary
 buildCommand="echo" # By default, no build will be triggered when a change occurs; use -c for a container-build (or -s for scratch).
 
 checkrecentupdates () {
@@ -83,7 +83,7 @@ $0 -b 7.yy.x -w \$(pwd)      -f Dockerfile        -maxdepth 1 --tag '1\.13|8\.[0
 	--no-commit, -n    do not commit to BRANCH
 	--no-push, -p      do not push to BRANCH
 	--tag              regex match to restrict results, eg., '1\.13|8\.[0-9]-' to find golang 1.13 (not 1.14) and any ubi 8-x- tag
-	-pr-only, -pr	   do not push directly to BRANCH, always generate PR instead
+	--pr               always generate PR against BRANCH
 	-prb               set a PR_BRANCH; default: pr-new-base-images-(timestamp)
 	-o                 open browser if PR generated
 	-q, -v             quiet, verbose output
@@ -111,7 +111,7 @@ while [[ "$#" -gt 0 ]]; do
     '-s') buildCommand="rhpkg container-build --scratch"; shift 0;;
     '-n'|'--nocommit'|'--no-commit') docommit=0; dopush=0; shift 0;;
     '-p'|'--nopush'|'--no-push') dopush=0; shift 0;;
-	'-pr'|'--pronly'|'--pr-only') dopronly=1; shift 0;;
+    '--pr') dopronly=1; dopush=0; shift 0;;
     '-prb') PR_BRANCH="$2"; shift 1;;
     '-o') OPENBROWSERFLAG="-o"; shift 0;;
     '-q') QUIET=1; shift 0;;
@@ -269,12 +269,10 @@ for d in $(find ${WORKDIR}/ -maxdepth ${MAXDEPTH} -name ${DOCKERFILE} | sort -r)
 								git add ${DOCKERFILE} || true
 								git commit -s -m "chore: Update from ${URL} to ${FROMPREFIX}:${LATESTTAG}" ${DOCKERFILE}
 								if [[ ${dopronly} -eq 1]]; then
-									if [[ ${dopush} -eq 1 ]]; then
-										createPr ${PR_BRANCH} ${BRANCHUSED}
-									fi
+									createPr ${PR_BRANCH} ${BRANCHUSED}
 								else
-									git pull origin "${BRANCHUSED}"
 									if [[ ${dopush} -eq 1 ]]; then
+										git pull origin "${BRANCHUSED}"
 										PUSH_TRY="$(git push origin "${BRANCHUSED}" 2>&1 || true)"
 										# shellcheck disable=SC2181
 										if [[ $? -gt 0 ]] || [[ $PUSH_TRY == *"protected branch hook declined"* ]]; then

--- a/product/updateBaseImages.sh
+++ b/product/updateBaseImages.sh
@@ -83,7 +83,7 @@ $0 -b 7.yy.x -w \$(pwd)      -f Dockerfile        -maxdepth 1 --tag '1\.13|8\.[0
 	--no-commit, -n    do not commit to BRANCH
 	--no-push, -p      do not push to BRANCH
 	--tag              regex match to restrict results, eg., '1\.13|8\.[0-9]-' to find golang 1.13 (not 1.14) and any ubi 8-x- tag
-	--pr               always generate PR against BRANCH
+	--pr               do not attempt to push directly; generate PR against BRANCH
 	-prb               set a PR_BRANCH; default: pr-new-base-images-(timestamp)
 	-o                 open browser if PR generated
 	-q, -v             quiet, verbose output

--- a/product/updateBaseImages.sh
+++ b/product/updateBaseImages.sh
@@ -177,7 +177,7 @@ createPr() {
 	git merge $2
 	lastCommitComment="$(git log -1 --pretty=%B)"
 	if [[ $(/usr/local/bin/hub version 2>/dev/null || true) ]] || [[ $(which hub 2>/dev/null || true) ]]; then
-		hub pull-request -f -m "${lastCommitComment} -b "${BRANCHUSED}" -h "${PR_BRANCH}" "${OPENBROWSERFLAG}" || true 
+		hub pull-request -f -m "${lastCommitComment}" -b "${BRANCHUSED}" -h "${PR_BRANCH}" "${OPENBROWSERFLAG}" || true 
 	else
 		echo "# Warning: hub is required to generate pull requests. See https://hub.github.com/ to install it."
 		echo -n "# To manually create a pull request, go here: "


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Add option to enforce creation of PR when updating base images, to prevent unwanted direct push to target main branch

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/18831

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
