### PR TITLE
fix:CRW-1951 - Use a VS Code Language support for Camel extension version compatible with 8 months old VS Code API 1.50.0

### DIFF
--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -375,7 +375,7 @@ plugins:
     extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-php-debug/php-debug-1.13.0.vsix
   - repository:
       url: 'https://github.com/camel-tooling/camel-lsp-client-vscode'
-      revision: 0.0.31
+      revision: 0.0.28
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.11"
       name: vscode-apache-camel
@@ -386,10 +386,7 @@ plugins:
         - sh
         - -c
         - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-apache-camel/vscode-apache-camel-0.0.31-143.vsix
-    metaYaml:
-      skipDependencies:
-        - redhat/vscode-commons
+    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-apache-camel/vscode-apache-camel-0.0.28-26.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-xml'
       revision: 0.14.0


### PR DESCRIPTION
also removes the skipDependencies of vscode-commons which is useless as
there is no dependency from this extension to tvscode-commons

nota: it will remain VS Code Camel K that is not working but it requires more work so will be done in another PR

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?

Use a VS Code Language support for Camel compatible with 8 months old VS Code API 1.50.0

### What issues does this PR fix or reference?

[CRW-1951](https://issues.redhat.com/browse/CRW-1951)

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
