### PR TITLE
fix: remove skipDependencies on vscode-commons as it is a required dependency

### DIFF
--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -167,9 +167,6 @@ plugins:
       cpuLimit: 500m
       cpuRequest: 30m
     extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-camelk/vscode-camelk-0.0.24-198.vsix
-    metaYaml:
-      skipDependencies:
-        - redhat/vscode-commons
   - repository:
       url: 'https://github.com/redhat-developer/vscode-microprofile'
       revision: 174c77f51a57bf1cfadba8f78ad7072ce63baa1d


### PR DESCRIPTION
as I do no tknow why the skipDependencies awas introduced exatly and there is no other extensions that have it and really need it. try to remove the skip. See https://issues.redhat.com/browse/CRW-1951?focusedCommentId=16450102&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16450102



<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?


### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
