### PR TITLE
feat CRW-1951 - Upgrade VS Code Camel K 0.0.26

### DIFF
--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -159,17 +159,14 @@ plugins:
     extension: https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-go/go-0.16.1.vsix
   - repository:
       url: 'https://github.com/camel-tooling/vscode-camelk'
-      revision: 0.0.24
+      revision: 0.0.26
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8:2.11"
       name: vscode-camelk
       memoryLimit: 1Gi
       cpuLimit: 500m
       cpuRequest: 30m
-    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-camelk/vscode-camelk-0.0.24-198.vsix
-    metaYaml:
-      skipDependencies:
-        - redhat/vscode-commons
+    extension: https://download.jboss.org/jbosstools/vscode/stable/vscode-camelk/vscode-camelk-0.0.26-336.vsix
   - repository:
       url: 'https://github.com/redhat-developer/vscode-microprofile'
       revision: 174c77f51a57bf1cfadba8f78ad7072ce63baa1d


### PR DESCRIPTION
no more declared dependency to vscode-commons (so can remove the
skipDependencies)

requires https://github.com/redhat-developer/codeready-workspaces-deprecated/pull/78

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?

 Upgrade VS Code Camel K to 0.0.26

### What issues does this PR fix or reference?

CRW-1951

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Upgrade VS Code Camel K to 0.0.26

#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
