### PR TITLE
fix: CRW-2075 - fix warning in script

### DIFF
--- a/dependencies/che-plugin-registry/build/scripts/swap_plugins_memory.sh
+++ b/dependencies/che-plugin-registry/build/scripts/swap_plugins_memory.sh
@@ -9,7 +9,6 @@
 
 # increase memory allocation for theia pods for ppc64le only - https://issues.redhat.com/browse/CRW-1475
 
-SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
 YAML_ROOT="$1"
 
 replaceField()
@@ -19,14 +18,14 @@ replaceField()
   updateVal="$3"
   # echo -n "Before: "; yq -r ${updateName} "${yamlFile}"
   # shellcheck disable=SC2086,SC2016
-  yq -Y --arg updateName "${updateName}" --arg updateVal "${updateVal}" ${updateName}' = $updateVal' ${yamlFile} > ${yamlFile}.2
+  yq -Y --arg updateName "${updateName}" --arg updateVal "${updateVal}" "${updateName}"' = $updateVal' ${yamlFile} > ${yamlFile}.2
   if [ -s "${yamlFile}".2 ]; then
     mv "${yamlFile}".2 "${yamlFile}"
-    echo -n "[INFO] $1 updated: "; yq -r ${updateName} "${yamlFile}"
+    echo -n "[INFO] $1 updated: "; yq -r "${updateName}" "${yamlFile}"
   else
     rm -f "${yamlFile}".2
     echo -n "[ERROR] Could not change field $2 in $1: "
-    yq -r ${updateName} "${yamlFile}"
+    yq -r "${updateName}" "${yamlFile}"
     exit 1
   fi
 }


### PR DESCRIPTION
which are failing some PR check

followed blindly the warnign reported in https://github.com/redhat-developer/codeready-workspaces/pull/553/checks?check_run_id=3124337760#step:3:12 not tested locally. Not sure what to check in the output to be sure that there is no extra double-quotes added.

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?


### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
