### PR TITLE
feat: urlRewriteSupported attribute added for theia and machine-exec

### DIFF
--- a/dependencies/che-plugin-registry/che-editors.yaml
+++ b/dependencies/che-plugin-registry/che-editors.yaml
@@ -50,6 +50,7 @@ editors:
                 type: main
                 cookiesAuthEnabled: true
                 discoverable: false
+                urlRewriteSupported: true
               protocol: http
             - name: webviews
               targetPort: 3100
@@ -61,6 +62,7 @@ editors:
                 cookiesAuthEnabled: true
                 discoverable: false
                 unique: true
+                urlRewriteSupported: true
             - name: mini-browser
               targetPort: 3100
               exposure: public
@@ -71,6 +73,7 @@ editors:
                 cookiesAuthEnabled: true
                 discoverable: false
                 unique: true
+                urlRewriteSupported: true
             - name: theia-dev
               targetPort: 3130
               exposure: public
@@ -78,24 +81,28 @@ editors:
               attributes:
                 type: ide-dev
                 discoverable: false
+                urlRewriteSupported: true
             - name: theia-redirect-1
               targetPort: 13131
               exposure: public
               protocol: http
               attributes:
                 discoverable: false
+                urlRewriteSupported: true
             - name: theia-redirect-2
               targetPort: 13132
               exposure: public
               protocol: http
               attributes:
                 discoverable: false
+                urlRewriteSupported: true
             - name: theia-redirect-3
               targetPort: 13133
               exposure: public
               protocol: http
               attributes:
                 discoverable: false
+                urlRewriteSupported: true
         attributes:
           ports:
             - exposedPort: 3100
@@ -128,6 +135,7 @@ editors:
                 type: collocated-terminal
                 discoverable: false
                 cookiesAuthEnabled: true
+                urlRewriteSupported: true
         attributes:
           ports:
             - exposedPort: 3333


### PR DESCRIPTION
Signed-off-by: xbaran4 <pbaran@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds urlRewriteSupported attribute for theia and che-machine-exec endpoints so that they can be served on subpath instead of subdomain.

### What issues does this PR fix or reference?
This is a backport of PR in Che upstream: https://github.com/eclipse-che/che-plugin-registry/pull/1013

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
