### PR TITLE
fix: adapt build scripts after removing VERSION file

### DIFF
--- a/dependencies/che-devfile-registry/build.sh
+++ b/dependencies/che-devfile-registry/build.sh
@@ -115,23 +115,8 @@ else
 fi
 
 IMAGE="${REGISTRY}/${ORGANIZATION}/${CONTAINERNAME}:${TAG}"
-VERSION=$(head -n 1 VERSION)
-case $VERSION in
-  *SNAPSHOT)
-    echo "Snapshot version (${VERSION}) specified in $(find . -name VERSION): building nightly plugin registry."
-    ${BUILDER} ${BUILD_COMMAND} \
-        -t "${IMAGE}" \
-        -f ${DOCKERFILE} \
-        --build-arg "USE_DIGESTS=${USE_DIGESTS}" \
-        --target "${TARGET}" .
-    ;;
-  *)
-    echo "Release version specified in $(find . -name VERSION): Building plugin registry for release ${VERSION}."
-    ${BUILDER} ${BUILD_COMMAND} \
-        -t "${IMAGE}" \
-        -f "${DOCKERFILE}" \
-        --build-arg "PATCHED_IMAGES_TAG=${VERSION}" \
-        --build-arg "USE_DIGESTS=${USE_DIGESTS}" \
-        --target "${TARGET}" .
-    ;;
-esac
+${BUILDER} ${BUILD_COMMAND} \
+    -t "${IMAGE}" \
+    -f ${DOCKERFILE} \
+    --build-arg "USE_DIGESTS=${USE_DIGESTS}" \
+    --target "${TARGET}" .

--- a/dependencies/che-plugin-registry/build.sh
+++ b/dependencies/che-plugin-registry/build.sh
@@ -126,8 +126,6 @@ if [ "${SKIP_OCI_IMAGE}" != "true" ]; then
     fi
     echo "Building with $BUILDER $BUILD_COMMAND"
     IMAGE="${REGISTRY}/${ORGANIZATION}/pluginregistry-rhel8:${TAG}"
-    VERSION=$(head -n 1 VERSION)
-    echo "Building che plugin registry ${VERSION}."
     # Copy to root directory to behave as if in Brew or codeready-workspaces-images
     cp "${DOCKERFILE}" ./builder.Dockerfile
     ${BUILDER} ${BUILD_COMMAND} -t "${IMAGE}" -f ./builder.Dockerfile .


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Fix the build by adapting build.sh scripts after [removing VERSION files](https://github.com/redhat-developer/codeready-workspaces/commit/56661aa0b8e08463d874a29b63cd09fe949da32e#diff-1597e4b1db53cf9ead740724cf5be6968e40d0d6dcd5d482762fe3820f8f14bc)

### What issues does this PR fix or reference?

N/A

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
N/A