### PR TITLE
fix(plugin-registry): Should replace 2.11 image references in che-machine-exec-plugin devfile.yaml and theia-ide devfile.yaml with RELATED_IMAGE env vars

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
@@ -38,6 +38,39 @@ METAS_DIR="${METAS_DIR:-${DEFAULT_METAS_DIR}}"
 IMAGE_REGEX="([[:space:]>-]*[\r]?[[:space:]]*[\"']?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)([\"']?)"
 
 function run_main() {
+
+    extract_and_use_related_images_env_variables_with_image_digest_info
+
+    update_container_image_references
+
+    # For testing, the images used for the che-theia, theia runtime, and machine-exec
+    # plugins can be overridden via the environment variables
+    #     CHE_PLUGIN_REGISTRY_THEIA_IMAGE
+    #     CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE
+    #     CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE
+    # If set, these env vars override all modifications
+    # (e.g. via CHE_DEVFILE_IMAGES_REGISTRY_URL)
+    #
+    if [ -n "$CHE_PLUGIN_REGISTRY_THEIA_IMAGE" ]; then
+    echo "Overriding Che Theia image with $CHE_PLUGIN_REGISTRY_THEIA_IMAGE"
+    sed -i -E "s|image:.*theia-rhel8.*|image: $CHE_PLUGIN_REGISTRY_THEIA_IMAGE|" "${metas[@]}"
+    fi
+
+    if [ -n "$CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE" ]; then
+    echo "Overriding Theia remote runtime image with $CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE"
+    sed -i -E "s|image:.*theia-endpoint-rhel8.*|image: $CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE|" "${metas[@]}"
+    fi
+
+    if [ -n "$CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE" ]; then
+    echo "Overriding Theia remote runtime image with $CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE"
+    sed -i -E "s|image:.*machineexec-rhel8.*|image: $CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE|" "${metas[@]}"
+    fi
+
+    exec "${@}"
+
+}
+
+function extract_and_use_related_images_env_variables_with_image_digest_info() {
     # Extract and use env variables with image digest information.
     # Env variable name format: 
     # RELATED_IMAGES_(Image_name)_(Image_label)_(Encoded_base32_image_tag)
@@ -75,7 +108,7 @@ function run_main() {
         done
         echo "--------------------------------------------------------------"
 
-        readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml')
+        readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml' -o -name 'devfile.yaml')
         for meta in "${metas[@]}"; do
             readarray -t images < <(grep "image:" "${meta}" | sed -r "s;.*image:[[:space:]]*'?\"?([._:a-zA-Z0-9-]*/?[._a-zA-Z0-9-]*/[._a-zA-Z0-9-]*(@sha256)?:?[._a-zA-Z0-9-]*)'?\"?[[:space:]]*;\1;")
             for image in "${images[@]}"; do
@@ -124,7 +157,7 @@ function run_main() {
             done
             echo "--------------------------------------------------------------"
 
-            readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml')
+            readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml' -o -name 'devfile.yaml')
             for meta in "${metas[@]}"; do
                 readarray -t images < <(grep "image:" "${meta}" | sed -r "s;.*image:[[:space:]]*'?\"?([._:a-zA-Z0-9-]*/?[._a-zA-Z0-9-]*/[._a-zA-Z0-9-]*(@sha256)?:?[._a-zA-Z0-9-]*)'?\"?[[:space:]]*;\1;")
                 for image in "${images[@]}"; do
@@ -147,34 +180,6 @@ function run_main() {
             done
         fi
     fi
-
-    update_container_image_references
-
-    # For testing, the images used for the che-theia, theia runtime, and machine-exec
-    # plugins can be overridden via the environment variables
-    #     CHE_PLUGIN_REGISTRY_THEIA_IMAGE
-    #     CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE
-    #     CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE
-    # If set, these env vars override all modifications
-    # (e.g. via CHE_DEVFILE_IMAGES_REGISTRY_URL)
-    #
-    if [ -n "$CHE_PLUGIN_REGISTRY_THEIA_IMAGE" ]; then
-    echo "Overriding Che Theia image with $CHE_PLUGIN_REGISTRY_THEIA_IMAGE"
-    sed -i -E "s|image:.*theia-rhel8.*|image: $CHE_PLUGIN_REGISTRY_THEIA_IMAGE|" "${metas[@]}"
-    fi
-
-    if [ -n "$CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE" ]; then
-    echo "Overriding Theia remote runtime image with $CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE"
-    sed -i -E "s|image:.*theia-endpoint-rhel8.*|image: $CHE_PLUGIN_REGISTRY_THEIA_ENDPOINT_RUNTIME_BINARY_IMAGE|" "${metas[@]}"
-    fi
-
-    if [ -n "$CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE" ]; then
-    echo "Overriding Theia remote runtime image with $CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE"
-    sed -i -E "s|image:.*machineexec-rhel8.*|image: $CHE_PLUGIN_REGISTRY_MACHINE_EXEC_IMAGE|" "${metas[@]}"
-    fi
-
-    exec "${@}"
-
 }
 
 function update_container_image_references() {
@@ -182,7 +187,7 @@ function update_container_image_references() {
     # We can't use the `-d` option for readarray because
     # registry.centos.org/centos/httpd-24-centos7 ships with Bash 4.2
     # The below command will fail if any path contains whitespace
-    readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml')
+    readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml' -o -name 'devfile.yaml')
     for meta in "${metas[@]}"; do
     echo "Checking meta $meta"
     # Need to update each field separately in case they are not defined.

--- a/dependencies/che-plugin-registry/build/dockerfiles/test_entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/test_entrypoint.sh
@@ -33,7 +33,10 @@ function initTest() {
     rm -rf "${METAS_DIR:?}"/*
     unset CHE_SIDECAR_CONTAINERS_REGISTRY_URL \
           CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION \
-          CHE_SIDECAR_CONTAINERS_REGISTRY_TAG
+          CHE_SIDECAR_CONTAINERS_REGISTRY_TAG \
+          RELATED_IMAGE_codeready_workspaces_theia_endpoint_plugin_registry_image_GIXDCMIK \
+          RELATED_IMAGE_codeready_workspaces_machineexec_plugin_registry_image_GIXDCMIK \
+          RELATED_IMAGE_codeready_workspaces_theia_plugin_registry_image_GIXDCMIK
 
 }
 
@@ -354,3 +357,358 @@ source "${script_dir}/entrypoint.sh"
 update_container_image_references
 
 assertFileContentEquals "${METAS_DIR}/meta.yaml" "${expected_metayaml}"
+
+#################################################################
+initTest "Should replace 2.11 image references in theia-ide devfile.yaml with RELATED_IMAGE env vars "
+
+devfileyaml=$(cat <<-END
+schemaVersion: 2.1.0
+metadata:
+  name: theia-ide
+commands:
+  - id: init-container-command
+    apply:
+      component: remote-runtime-injector
+events:
+  preStart:
+    - init-container-command
+components:
+  - name: theia-ide
+    container:
+      image: 'registry.redhat.io/codeready-workspaces/theia-rhel8:2.11'
+      env:
+        - name: THEIA_PLUGINS
+          value: 'local-dir:///plugins'
+        - name: HOSTED_PLUGIN_HOSTNAME
+          value: 0.0.0.0
+        - name: HOSTED_PLUGIN_PORT
+          value: '3130'
+        - name: THEIA_HOST
+          value: 0.0.0.0
+      volumeMounts:
+        - name: plugins
+          path: /plugins
+        - name: theia-local
+          path: /home/theia/.theia
+      mountSources: true
+      memoryLimit: 512M
+      cpuLimit: 1500m
+      cpuRequest: 100m
+      endpoints:
+        - name: theia
+          attributes:
+            type: main
+            cookiesAuthEnabled: true
+            discoverable: false
+          targetPort: 3100
+          exposure: public
+          secure: false
+          protocol: https
+        - name: webviews
+          attributes:
+            type: webview
+            cookiesAuthEnabled: true
+            discoverable: false
+            unique: true
+          targetPort: 3100
+          exposure: public
+          secure: false
+          protocol: https
+        - name: mini-browser
+          attributes:
+            type: mini-browser
+            cookiesAuthEnabled: true
+            discoverable: false
+            unique: true
+          targetPort: 3100
+          exposure: public
+          secure: false
+          protocol: https
+        - name: theia-dev
+          attributes:
+            type: ide-dev
+            discoverable: false
+          targetPort: 3130
+          exposure: public
+          protocol: http
+        - name: theia-redirect-1
+          attributes:
+            discoverable: false
+          targetPort: 13131
+          exposure: public
+          protocol: http
+        - name: theia-redirect-2
+          attributes:
+            discoverable: false
+          targetPort: 13132
+          exposure: public
+          protocol: http
+        - name: theia-redirect-3
+          attributes:
+            discoverable: false
+          targetPort: 13133
+          exposure: public
+          protocol: http
+        - name: terminal
+          attributes:
+            type: collocated-terminal
+            discoverable: false
+            cookiesAuthEnabled: true
+          targetPort: 3333
+          exposure: public
+          secure: false
+          protocol: wss
+    attributes: {}
+  - name: plugins
+    volume: {}
+  - name: theia-local
+    volume: {}
+  - name: che-machine-exec
+    container:
+      image: 'registry.redhat.io/codeready-workspaces/machineexec-rhel8:2.11'
+      command:
+        - /go/bin/che-machine-exec
+        - '--url'
+        - '0.0.0.0:3333'
+      memoryLimit: 128Mi
+      memoryRequest: 32Mi
+      cpuLimit: 500m
+      cpuRequest: 30m
+    attributes: {}
+  - name: remote-runtime-injector
+    container:
+      image: 'registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8:2.11'
+      env:
+        - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+          value: /remote-endpoint/plugin-remote-endpoint
+        - name: REMOTE_ENDPOINT_VOLUME_NAME
+          value: remote-endpoint
+      volumeMounts:
+        - name: remote-endpoint
+          path: /remote-endpoint
+      memoryLimit: 128Mi
+      memoryRequest: 32Mi
+      cpuLimit: 500m
+      cpuRequest: 30m
+  - name: remote-endpoint
+    volume:
+      ephemeral: true
+END
+)
+expected_devfileyaml=$(cat <<-END
+schemaVersion: 2.1.0
+metadata:
+  name: theia-ide
+commands:
+  - id: init-container-command
+    apply:
+      component: remote-runtime-injector
+events:
+  preStart:
+    - init-container-command
+components:
+  - name: theia-ide
+    container:
+      image: 'registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:be279f90a9aeeb885fcedca4749396ce16825eb66947900b549cfdf16f97dfeb'
+      env:
+        - name: THEIA_PLUGINS
+          value: 'local-dir:///plugins'
+        - name: HOSTED_PLUGIN_HOSTNAME
+          value: 0.0.0.0
+        - name: HOSTED_PLUGIN_PORT
+          value: '3130'
+        - name: THEIA_HOST
+          value: 0.0.0.0
+      volumeMounts:
+        - name: plugins
+          path: /plugins
+        - name: theia-local
+          path: /home/theia/.theia
+      mountSources: true
+      memoryLimit: 512M
+      cpuLimit: 1500m
+      cpuRequest: 100m
+      endpoints:
+        - name: theia
+          attributes:
+            type: main
+            cookiesAuthEnabled: true
+            discoverable: false
+          targetPort: 3100
+          exposure: public
+          secure: false
+          protocol: https
+        - name: webviews
+          attributes:
+            type: webview
+            cookiesAuthEnabled: true
+            discoverable: false
+            unique: true
+          targetPort: 3100
+          exposure: public
+          secure: false
+          protocol: https
+        - name: mini-browser
+          attributes:
+            type: mini-browser
+            cookiesAuthEnabled: true
+            discoverable: false
+            unique: true
+          targetPort: 3100
+          exposure: public
+          secure: false
+          protocol: https
+        - name: theia-dev
+          attributes:
+            type: ide-dev
+            discoverable: false
+          targetPort: 3130
+          exposure: public
+          protocol: http
+        - name: theia-redirect-1
+          attributes:
+            discoverable: false
+          targetPort: 13131
+          exposure: public
+          protocol: http
+        - name: theia-redirect-2
+          attributes:
+            discoverable: false
+          targetPort: 13132
+          exposure: public
+          protocol: http
+        - name: theia-redirect-3
+          attributes:
+            discoverable: false
+          targetPort: 13133
+          exposure: public
+          protocol: http
+        - name: terminal
+          attributes:
+            type: collocated-terminal
+            discoverable: false
+            cookiesAuthEnabled: true
+          targetPort: 3333
+          exposure: public
+          secure: false
+          protocol: wss
+    attributes: {}
+  - name: plugins
+    volume: {}
+  - name: theia-local
+    volume: {}
+  - name: che-machine-exec
+    container:
+      image: 'registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:bfdd8cf61a6fad757f1e8334aa84dbf44baddf897ff8def7496bf6dbc066679d'
+      command:
+        - /go/bin/che-machine-exec
+        - '--url'
+        - '0.0.0.0:3333'
+      memoryLimit: 128Mi
+      memoryRequest: 32Mi
+      cpuLimit: 500m
+      cpuRequest: 30m
+    attributes: {}
+  - name: remote-runtime-injector
+    container:
+      image: 'registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:cda289285594c87d1acfb77543aae109973cd1b84953bde061a27889423979c5'
+      env:
+        - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+          value: /remote-endpoint/plugin-remote-endpoint
+        - name: REMOTE_ENDPOINT_VOLUME_NAME
+          value: remote-endpoint
+      volumeMounts:
+        - name: remote-endpoint
+          path: /remote-endpoint
+      memoryLimit: 128Mi
+      memoryRequest: 32Mi
+      cpuLimit: 500m
+      cpuRequest: 30m
+  - name: remote-endpoint
+    volume:
+      ephemeral: true
+END
+)
+echo "$devfileyaml" > "${METAS_DIR}/devfile.yaml"
+export RELATED_IMAGE_codeready_workspaces_theia_endpoint_plugin_registry_image_GIXDCMIK='registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:cda289285594c87d1acfb77543aae109973cd1b84953bde061a27889423979c5'
+export RELATED_IMAGE_codeready_workspaces_machineexec_plugin_registry_image_GIXDCMIK='registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:bfdd8cf61a6fad757f1e8334aa84dbf44baddf897ff8def7496bf6dbc066679d'
+export RELATED_IMAGE_codeready_workspaces_theia_plugin_registry_image_GIXDCMIK='registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:be279f90a9aeeb885fcedca4749396ce16825eb66947900b549cfdf16f97dfeb'
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+
+extract_and_use_related_images_env_variables_with_image_digest_info
+
+assertFileContentEquals "${METAS_DIR}/devfile.yaml" "${expected_devfileyaml}"
+
+
+
+
+#################################################################
+initTest "Should replace 2.11 image references in che-machine-exec-plugin devfile.yaml with RELATED_IMAGE env vars "
+
+devfileyaml=$(cat <<-END
+schemaVersion: 2.1.0
+metadata:
+  name: Che machine-exec Service
+components:
+  - name: che-machine-exec
+    container:
+      image: 'registry.redhat.io/codeready-workspaces/machineexec-rhel8:2.11'
+      command:
+        - /go/bin/che-machine-exec
+        - '--url'
+        - '0.0.0.0:4444'
+      memoryLimit: 128Mi
+      memoryRequest: 32Mi
+      cpuLimit: 500m
+      cpuRequest: 30m
+      endpoints:
+        - name: che-machine-exec
+          attributes:
+            type: terminal
+            discoverable: false
+            cookiesAuthEnabled: true
+          targetPort: 4444
+          exposure: public
+          secure: false
+          protocol: wss
+END
+)
+expected_devfileyaml=$(cat <<-END
+schemaVersion: 2.1.0
+metadata:
+  name: Che machine-exec Service
+components:
+  - name: che-machine-exec
+    container:
+      image: 'registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:bfdd8cf61a6fad757f1e8334aa84dbf44baddf897ff8def7496bf6dbc066679d'
+      command:
+        - /go/bin/che-machine-exec
+        - '--url'
+        - '0.0.0.0:4444'
+      memoryLimit: 128Mi
+      memoryRequest: 32Mi
+      cpuLimit: 500m
+      cpuRequest: 30m
+      endpoints:
+        - name: che-machine-exec
+          attributes:
+            type: terminal
+            discoverable: false
+            cookiesAuthEnabled: true
+          targetPort: 4444
+          exposure: public
+          secure: false
+          protocol: wss
+END
+)
+echo "$devfileyaml" > "${METAS_DIR}/devfile.yaml"
+export RELATED_IMAGE_codeready_workspaces_theia_endpoint_plugin_registry_image_GIXDCMIK='registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:cda289285594c87d1acfb77543aae109973cd1b84953bde061a27889423979c5'
+export RELATED_IMAGE_codeready_workspaces_machineexec_plugin_registry_image_GIXDCMIK='registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:bfdd8cf61a6fad757f1e8334aa84dbf44baddf897ff8def7496bf6dbc066679d'
+export RELATED_IMAGE_codeready_workspaces_theia_plugin_registry_image_GIXDCMIK='registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:be279f90a9aeeb885fcedca4749396ce16825eb66947900b549cfdf16f97dfeb'
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+
+extract_and_use_related_images_env_variables_with_image_digest_info
+
+assertFileContentEquals "${METAS_DIR}/devfile.yaml" "${expected_devfileyaml}"


### PR DESCRIPTION
### What does this PR do?
1. Extract image references replacement with RELATED_IMAGE env vars to a function to be able to unit test it
2. Fix image references replacement with RELATED_IMAGE env vars should also work for devfile.yaml files, not only meta.yaml.
3. Add unit tests.

### What issues does this PR fix or reference?
Fix https://issues.redhat.com/browse/CRW-2201

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
