### PR TITLE
fix(plugin-registry): Replace tag with digest in che-theia-plugin.yaml

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/entrypoint.sh
@@ -108,7 +108,7 @@ function extract_and_use_related_images_env_variables_with_image_digest_info() {
         done
         echo "--------------------------------------------------------------"
 
-        readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml' -o -name 'devfile.yaml')
+        readarray -t metas < <(find "${METAS_DIR}" -name 'meta.yaml' -o -name 'devfile.yaml' -o -name 'che-theia-plugin.yaml')
         for meta in "${metas[@]}"; do
             readarray -t images < <(grep "image:" "${meta}" | sed -r "s;.*image:[[:space:]]*'?\"?([._:a-zA-Z0-9-]*/?[._a-zA-Z0-9-]*/[._a-zA-Z0-9-]*(@sha256)?:?[._a-zA-Z0-9-]*)'?\"?[[:space:]]*;\1;")
             for image in "${images[@]}"; do

--- a/dependencies/che-plugin-registry/build/dockerfiles/test_entrypoint.sh
+++ b/dependencies/che-plugin-registry/build/dockerfiles/test_entrypoint.sh
@@ -712,3 +712,67 @@ source "${script_dir}/entrypoint.sh"
 extract_and_use_related_images_env_variables_with_image_digest_info
 
 assertFileContentEquals "${METAS_DIR}/devfile.yaml" "${expected_devfileyaml}"
+
+#################################################################
+initTest "Should replace image references in che-theia-plugin.yaml with RELATED_IMAGE env vars "
+
+cheTheiaPluginYaml=$(cat <<-END
+schemaVersion: 1.0.0
+metadata:
+  id: redhat/java11
+  publisher: redhat
+  name: java11
+  version: latest
+  displayName: Language Support for Java(TM) by Red Hat
+  description: 'Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...'
+  repository: 'https://github.com/redhat-developer/vscode-java'
+  categories:
+    - Programming Languages
+    - Linters
+    - Formatters
+    - Snippets
+  icon: /images/redhat-java-icon.png
+sidecar:
+  image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.11'
+  name: vscode-java
+  memoryLimit: 1500Mi
+  cpuLimit: 500m
+  cpuRequest: 30m
+extensions:
+  - 'relative:extension/resources/download_jboss_org/jbosstools/static/jdt_ls/stable/java-0.75.0-60.vsix'
+END
+)
+expected_cheTheiaPluginYaml=$(cat <<-END
+schemaVersion: 1.0.0
+metadata:
+  id: redhat/java11
+  publisher: redhat
+  name: java11
+  version: latest
+  displayName: Language Support for Java(TM) by Red Hat
+  description: 'Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...'
+  repository: 'https://github.com/redhat-developer/vscode-java'
+  categories:
+    - Programming Languages
+    - Linters
+    - Formatters
+    - Snippets
+  icon: /images/redhat-java-icon.png
+sidecar:
+  image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:d0337762e71fd4badabcb38a582b2f35e7e7fc1c9c0f2e841e339d45b7bd34ed'
+  name: vscode-java
+  memoryLimit: 1500Mi
+  cpuLimit: 500m
+  cpuRequest: 30m
+extensions:
+  - 'relative:extension/resources/download_jboss_org/jbosstools/static/jdt_ls/stable/java-0.75.0-60.vsix'
+END
+)
+echo "$cheTheiaPluginYaml" > "${METAS_DIR}/che-theia-plugin.yaml"
+export RELATED_IMAGE_codeready_workspaces_plugin_java11_plugin_registry_image_GIXDCMIK='registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:d0337762e71fd4badabcb38a582b2f35e7e7fc1c9c0f2e841e339d45b7bd34ed'
+# shellcheck disable=SC1090
+source "${script_dir}/entrypoint.sh"
+
+extract_and_use_related_images_env_variables_with_image_digest_info
+
+assertFileContentEquals "${METAS_DIR}/che-theia-plugin.yaml" "${expected_cheTheiaPluginYaml}"


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Replace **image:tag** with RELATED_IMAGE env variable in che-theia-plugin.yaml files at runtime.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2247
