### PR TITLE
feat(python-plugin): enabling venv and jupyter notebook

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/05_python/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_python/devfile.yaml
@@ -21,6 +21,9 @@ components:
     image: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8:2.13
     memoryLimit: 512Mi
     mountSources: true
+    volumes:
+      - name: venv
+        containerPath: /home/jboss/.venv
 commands:
   -
     name: 1. Run
@@ -28,7 +31,7 @@ commands:
       -
         type: exec
         component: python
-        command: "python hello-world.py"
+        command: python -m venv .venv && . .venv/bin/activate && python hello-world.py
         workdir: ${CHE_PROJECTS_ROOT}/python-hello-world
   -
     name: Debug current file

--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -131,14 +131,17 @@ plugins:
     sidecar:
       image: "registry.redhat.io/codeready-workspaces/plugin-java8-rhel8:2.13"
       name: vscode-python
-      memoryLimit: 512Mi
+      memoryLimit: 1Gi
       cpuLimit: 500m
       cpuRequest: 30m
+      volumeMounts:
+        - name: venv
+          path: /home/jboss/.venv
       args:
-        - sh
+        - bash
         - -c
         - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
-    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/vfa62888/vscode-python-2020.7.94776.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v34b6b7e/vscode-python-2020.7.94776.vsix
   - repository:
       url: 'https://github.com/golang/vscode-go'
       revision: v0.16.1


### PR DESCRIPTION
Signed-off-by: Sun Tan <sutan@redhat.com>

### What does this PR do?
Updating python extension to
- fix jupyter notebook issues
- enabling venv that should be shared as a volume in jupyter notebook or plain python devfiles
- updated python devfile to use the venv volume

### What issues does this PR fix or reference?
Fix https://issues.redhat.com/browse/CRW-1857
requiring https://github.com/redhat-developer/codeready-workspaces-images/pull/51 and https://github.com/redhat-developer/codeready-workspaces-deprecated/pull/76

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 

     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Jupyter Notebooks native support through the Python VS Code extension

#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
