### PR TITLE
Adding content repo that are public facing

### DIFF
--- a/dependencies/che-devfile-registry/build/dockerfiles/content_sets_ubi8.repo
+++ b/dependencies/che-devfile-registry/build/dockerfiles/content_sets_ubi8.repo
@@ -1,0 +1,20 @@
+[ubi-8-appstream]
+name=Red Hat Universal Base Image 8 (RPMs) - AppStream
+baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os
+enabled=1
+gpgcheck=0
+skip_if_unavailable=True
+
+[ubi-8-baseos]
+name=Red Hat Universal Base Image 8 (RPMs) - BaseOS
+baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os
+enabled=1
+gpgcheck=0
+skip_if_unavailable=True
+
+[ubi-8-codeready-builder]
+name=Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
+baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/os/
+enabled=1
+gpgcheck=0
+skip_if_unavailable=True

--- a/dependencies/che-plugin-registry/build/dockerfiles/content_sets_ubi8.repo
+++ b/dependencies/che-plugin-registry/build/dockerfiles/content_sets_ubi8.repo
@@ -1,0 +1,20 @@
+[ubi-8-appstream]
+name=Red Hat Universal Base Image 8 (RPMs) - AppStream
+baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os
+enabled=1
+gpgcheck=0
+skip_if_unavailable=True
+
+[ubi-8-baseos]
+name=Red Hat Universal Base Image 8 (RPMs) - BaseOS
+baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os
+enabled=1
+gpgcheck=0
+skip_if_unavailable=True
+
+[ubi-8-codeready-builder]
+name=Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
+baseurl=https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/os/
+enabled=1
+gpgcheck=0
+skip_if_unavailable=True


### PR DESCRIPTION
These public facing content repos are for an image update. This allows downstream products to more easily adopt CRW. @nickboldt

