### PR TITLE
CRW-2203, fix updateVersionAndRegistryTags.sh

### DIFF
--- a/dependencies/job-config.json
+++ b/dependencies/job-config.json
@@ -896,8 +896,8 @@
       },
       "2.x": {
         "upstream_branch": [
-          "main",
-          "main"
+          "0.9.x",
+          "0.9.x"
         ],
         "disabled": true
       }
@@ -926,8 +926,8 @@
       },
       "2.x": {
         "upstream_branch": [
-          "main",
-          "main"
+          "20210728",
+          "20210728"
         ],
         "disabled": false
       }

--- a/dependencies/job-config.json
+++ b/dependencies/job-config.json
@@ -19,10 +19,10 @@
       },
       "2.13": {
         "upstream_branch": [
-          "main",
-          "main"
+          "7.38.x",
+          "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -52,7 +52,7 @@
           "7.38.x",
           "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -82,7 +82,7 @@
           "7.38.x",
           "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -112,7 +112,7 @@
           "7.38.x",
           "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -142,7 +142,7 @@
           "7.38.x",
           "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -172,7 +172,7 @@
           "7.38.x",
           "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -202,7 +202,7 @@
           "7.38.x",
           "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -232,7 +232,7 @@
           "7.38.x",
           "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -262,7 +262,7 @@
           "7.38.x",
           "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -292,7 +292,7 @@
           "7.38.x",
           "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -322,7 +322,7 @@
           "7.38.x",
           "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -352,7 +352,7 @@
           "7.38.x",
           "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -382,7 +382,7 @@
           "7.38.x",
           "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -412,7 +412,7 @@
           "7.38.x",
           "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -442,7 +442,7 @@
           "7.38.x",
           "7.37.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -469,10 +469,10 @@
       },
       "2.13": {
         "upstream_branch": [
-          "crw-2-rhel-8",
-          "crw-2-rhel-8"
+          "crw-2.13-rhel-8",
+          "crw-2.13-rhel-8"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -499,10 +499,10 @@
       },
       "2.13": {
         "upstream_branch": [
-          "crw-2-rhel-8",
-          "crw-2-rhel-8"
+          "crw-2.13-rhel-8",
+          "crw-2.13-rhel-8"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -529,10 +529,10 @@
       },
       "2.13": {
         "upstream_branch": [
-          "crw-2-rhel-8",
-          "crw-2-rhel-8"
+          "crw-2.13-rhel-8",
+          "crw-2.13-rhel-8"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -559,10 +559,10 @@
       },
       "2.13": {
         "upstream_branch": [
-          "crw-2-rhel-8",
-          "crw-2-rhel-8"
+          "crw-2.13-rhel-8",
+          "crw-2.13-rhel-8"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -589,10 +589,10 @@
       },
       "2.13": {
         "upstream_branch": [
-          "crw-2-rhel-8",
-          "crw-2-rhel-8"
+          "crw-2.13-rhel-8",
+          "crw-2.13-rhel-8"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -619,10 +619,10 @@
       },
       "2.13": {
         "upstream_branch": [
-          "crw-2-rhel-8",
-          "crw-2-rhel-8"
+          "crw-2.13-rhel-8",
+          "crw-2.13-rhel-8"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -649,10 +649,10 @@
       },
       "2.13": {
         "upstream_branch": [
-          "crw-2-rhel-8",
-          "crw-2-rhel-8"
+          "crw-2.13-rhel-8",
+          "crw-2.13-rhel-8"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -679,10 +679,10 @@
       },
       "2.13": {
         "upstream_branch": [
-          "crw-2-rhel-8",
-          "crw-2-rhel-8"
+          "crw-2.13-rhel-8",
+          "crw-2.13-rhel-8"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -709,10 +709,10 @@
       },
       "2.13": {
         "upstream_branch": [
-          "crw-2-rhel-8",
-          "crw-2-rhel-8"
+          "crw-2.13-rhel-8",
+          "crw-2.13-rhel-8"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -739,10 +739,10 @@
       },
       "2.13": {
         "upstream_branch": [
-          "crw-2-rhel-8",
-          "crw-2-rhel-8"
+          "crw-2.13-rhel-8",
+          "crw-2.13-rhel-8"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -769,10 +769,10 @@
       },
       "2.13": {
         "upstream_branch": [
-          "crw-2-rhel-8",
-          "crw-2-rhel-8"
+          "crw-2.13-rhel-8",
+          "crw-2.13-rhel-8"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -799,10 +799,10 @@
       },
       "2.13": {
         "upstream_branch": [
-          "crw-2-rhel-8",
-          "crw-2-rhel-8"
+          "crw-2.13-rhel-8",
+          "crw-2.13-rhel-8"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -832,7 +832,7 @@
           "v3.4.x",
           "v3.4.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -862,7 +862,7 @@
           "v3.4.x",
           "v3.4.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -892,7 +892,7 @@
           "0.9.x",
           "0.9.x"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -922,7 +922,7 @@
           "20210728",
           "20210728"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -952,7 +952,7 @@
           "v2.5.0",
           "v2.5.0"
         ],
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "upstream_branch": [
@@ -972,7 +972,7 @@
         "disabled": false
       },
       "2.13": {
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "disabled": false
@@ -986,7 +986,7 @@
         "disabled": false
       },
       "2.13": {
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "disabled": false
@@ -1000,7 +1000,7 @@
         "disabled": false
       },
       "2.13": {
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "disabled": false
@@ -1014,7 +1014,7 @@
         "disabled": false
       },
       "2.13": {
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "disabled": false
@@ -1028,7 +1028,7 @@
         "disabled": false
       },
       "2.13": {
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "disabled": false
@@ -1042,7 +1042,7 @@
         "disabled": false
       },
       "2.13": {
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "disabled": false
@@ -1056,7 +1056,7 @@
         "disabled": false
       },
       "2.13": {
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "disabled": false
@@ -1070,7 +1070,7 @@
         "disabled": true
       },
       "2.13": {
-        "disabled": true
+        "disabled": false
       },
       "2.x": {
         "disabled": true

--- a/product/updateVersionAndRegistryTags.sh
+++ b/product/updateVersionAndRegistryTags.sh
@@ -96,8 +96,8 @@ updateVersion() {
     # otherwise inject new version.
     check=$(cat ${WORKDIR}/dependencies/job-config.json | jq '.Jobs[] | keys' | grep "\"${CRW_VERSION}\"")
     if [[ ${check} ]]; then #just updating
-      replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"]|select(.[]?==\"main\"))" "[\"7.${UPPER_CHE_Y}.x\",\"7.${LOWER_CHE_Y}.x\"]"
-      replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"]|select(.[]?==\"crw-2-rhel-8\"))" "[\"${BRANCH}\",\"${BRANCH}\"]"
+      replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"][\"upstream_branch\"]|select(.[]?==\"main\"))" "[\"7.${UPPER_CHE_Y}.x\",\"7.${LOWER_CHE_Y}.x\"]"
+      replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"][\"upstream_branch\"]|select(.[]?==\"crw-2-rhel-8\"))" "[\"crw-${CRW_VERSION}-rhel-8\",\"crw-${CRW_VERSION}-rhel-8\"]"
       #make sure jobs are enabled
       replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"][\"disabled\"]|select(.==true))" 'false'
       replaceField "${WORKDIR}/dependencies/job-config.json" "(.\"Management-Jobs\"[][\"${CRW_VERSION}\"][\"disabled\"]|select(.==true))" 'false'
@@ -132,8 +132,8 @@ updateVersion() {
         fi
       done
 
-      replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"]|select(.[]?==\"main\"))" "[\"7.${UPPER_CHE_Y}.x\",\"7.${LOWER_CHE_Y}.x\"]"
-      replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"]|select(.[]?==\"crw-2-rhel-8\"))" "[\"${BRANCH}\",\"${BRANCH}\"]"
+      replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"][\"upstream_branch\"]|select(.[]?==\"main\"))" "[\"7.${UPPER_CHE_Y}.x\",\"7.${LOWER_CHE_Y}.x\"]"
+      replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"][\"upstream_branch\"]|select(.[]?==\"crw-2-rhel-8\"))" "[\"crw-${CRW_VERSION}-rhel-8\",\"crw-${CRW_VERSION}-rhel-8\"]"
 
       #make sure new builds are enabled
       replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"][\"disabled\"]|select(.==true))" 'false'

--- a/product/updateVersionAndRegistryTags.sh
+++ b/product/updateVersionAndRegistryTags.sh
@@ -132,19 +132,8 @@ updateVersion() {
         fi
       done
 
-      #if che branches exist then update to those instead of main; check against https://github.com/che-incubator/chectl
-      UPPER_CHE_CHECK=$(git ls-remote --heads https://github.com/che-incubator/chectl.git 7.${UPPER_CHE_Y}.x)
-      LOWER_CHE_CHECK=$(git ls-remote --heads https://github.com/che-incubator/chectl.git 7.${LOWER_CHE_Y}.x)
-      #if either one exists then update the new crw version to use the che versioned branches instead of main
-      if [ $UPPER_CHE_CHECK ] || [ $LOWER_CHE_CHECK ]; then
-        replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"]|select(.[]?==\"main\"))" "[\"7.${UPPER_CHE_Y}.x\",\"7.${LOWER_CHE_Y}.x\"]"
-      fi
-
-      #if crw-2.yy exists use that instead of crw-2-rhel-8
-      CRW_CHECK=$(git ls-remote --heads https://github.com/redhat-developer/codeready-workspaces.git ${BRANCH})
-      if [[ $CRW_CHECK ]]; then
-        replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"]|select(.[]?==\"crw-2-rhel-8\"))" "[\"${BRANCH}\",\"${BRANCH}\"]"
-      fi
+      replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"]|select(.[]?==\"main\"))" "[\"7.${UPPER_CHE_Y}.x\",\"7.${LOWER_CHE_Y}.x\"]"
+      replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"]|select(.[]?==\"crw-2-rhel-8\"))" "[\"${BRANCH}\",\"${BRANCH}\"]"
 
       #make sure new builds are enabled
       replaceField "${WORKDIR}/dependencies/job-config.json" "(.Jobs[][\"${CRW_VERSION}\"][\"disabled\"]|select(.==true))" 'false'


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
- takes out the check for upstream branches and so the script updates the upstream_branch field with 7.yy.x/crw-2.yy-rhel-8 
- use CRW_VERSION to set crw-2.yy-rhel-8 branch since the passed in BRANCH is crw-2-rhel-8
- fix jq commands that broke when I added the upstream_branch field to the json


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2203

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
