### PR TITLE
Fix: adding 2.12, 2.13 and 2.x versions back for devworkspace-controller

### DIFF
--- a/dependencies/job-config.json
+++ b/dependencies/job-config.json
@@ -879,6 +879,27 @@
           "0.9.x"
         ],
         "disabled": true
+      },
+      "2.12": {
+        "upstream_branch": [
+          "0.9.x",
+          "0.9.x"
+        ],
+        "disabled": true
+      },
+      "2.13": {
+        "upstream_branch": [
+          "0.9.x",
+          "0.9.x"
+        ],
+        "disabled": false
+      },
+      "2.x": {
+        "upstream_branch": [
+          "0.9.x",
+          "0.9.x"
+        ],
+        "disabled": true
       }
     },
     "idea": {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Explained in title: 2.12, 2.13, 2.x got taken out from job-config.json and caused operator jenkins builds to break because it references the devworkspace branch.

### What issues does this PR fix or reference?
Related to https://issues.redhat.com/browse/CRW-2203
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
