### PR TITLE
chore: Update the GitHub PR plugin to 0.21.1

### DIFF
--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -5,7 +5,7 @@ plugins:
       revision: 0.20.0
     aliases:
       - ms-vscode/vscode-github-pullrequest
-    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/vdb8b64f/vscode-pull-request-github-0.20.0.vsix
+    extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v4c5e8c4/vscode-pull-request-github-0.21.1.vsix
   - repository:
       url: 'https://github.com/Microsoft/vscode-node-debug'
       revision: v1.41.1


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Update the GitHub Pull Request plugin to 0.21.1 which uses `registerFileDecorationProvider` instead of previous `registerDecorationProvider` plugin API method.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
fixes https://github.com/eclipse/che/issues/20689

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
