### PR TITLE
fix: feat: chore: extract a kinit method we can call it separately from longer slower bootstrap()

### DIFF
--- a/product/util.groovy
+++ b/product/util.groovy
@@ -690,6 +690,7 @@ def installRedHatInternalCerts() {
 }
 
 def sshMountRcmGuest() {
+  installSshfs()
   DESTHOST="crw-build/codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com@rcm-guest.app.eng.bos.redhat.com"
   sh('''#!/bin/bash -xe
 # accept host key

--- a/product/util.groovy
+++ b/product/util.groovy
@@ -731,8 +731,9 @@ Host pkgs.devel.redhat.com
 User ''' + KERBEROS_USER + '''
 " > ~/.ssh/config
 chmod 600 ~/.ssh/config
-# initialize kerberos
-export KRB5CCNAME=/var/tmp/crw-build_ccache
+
+# don't use specific file; use whatever default keyring is present
+# export KRB5CCNAME=/var/tmp/crw-build_ccache
 
 # if no kerb ticket for crw-build user, attempt to create one
 if [[ ! $(klist | grep crw-build) ]]; then

--- a/product/util.groovy
+++ b/product/util.groovy
@@ -732,7 +732,7 @@ User ''' + KERBEROS_USER + '''
 " > ~/.ssh/config
 chmod 600 ~/.ssh/config
 
-# don't use specific file; use whatever default keyring is present
+# CRW-1919 DON'T use specific cache file; use whatever default keyring is present so we don't have to export an env var with every single shell
 # export KRB5CCNAME=/var/tmp/crw-build_ccache
 
 # if no kerb ticket for crw-build user, attempt to create one
@@ -744,9 +744,9 @@ if [[ ! $(klist | grep crw-build) ]]; then
     keytab=$(find /mnt/hudson_workspace/ $HOME $WORKSPACE -name "*crw-build*keytab*" 2>/dev/null | head -1)
   fi
   kinit "''' + KERBEROS_USER + '''" -kt $keytab
-  klist
 fi
 ''')
+  // default shell, not specifically bash
   if (verbose) { sh('''klist''') }
 
 }


### PR DESCRIPTION
### What does this PR do?

extract a kinit method we can call separate from bootstrap(); add new method for sshMountRcmGuest (used by crwctl and crw sources builds)

Change-Id: I8f4e2b5424f889df6fee57d6dc0ea6de21c739f6
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1919

### How to test this PR?

```
#!/usr/bin/env groovy
import groovy.transform.Field

timeout(120) {
    node("rhel83") { 
        stage ("Build on rhel83") {
            currentBuild.description="Run on " + NODE_NAME + " (" + NODE_LABELS + ")"
            wrap([$class: 'TimestamperBuildWrapper']) {
                sh('curl -sSLO https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/crw-2-rhel-8/product/util.groovy')
                def util = load "${WORKSPACE}/util.groovy"
                withCredentials([
                    string(credentialsId:'crw_devstudio-release-token', variable: 'GITHUB_TOKEN'),
                    string(credentialsId: 'quay.io-crw-crwci_user_token', variable: 'QUAY_TOKEN'),
                    file(credentialsId: 'crw_crw-build-keytab', variable: 'CRW_KEYTAB'),
                    usernamePassword(credentialsId: 'registry.redhat.io_crw_bot', usernameVariable: 'CRW_BOT_USERNAME', passwordVariable: 'CRW_BOT_PASSWORD')
                ]) {
                  cleanWs()
                  util.kinit(true)
                  DESTHOST=util.sshMountRcmGuest()
            sh '''#!/bin/bash -xe
ssh "''' + DESTHOST + '''" "cd /mnt/rcm-guest/staging/crw; ls -la */"
'''
                } // with
            } // wrap
        } // stage
    } // node 
} // timeout
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.