### PR TITLE
chore: add voulumeMount for .kube folder

### DIFF
--- a/dependencies/che-plugin-registry/che-theia-plugins.yaml
+++ b/dependencies/che-plugin-registry/che-theia-plugins.yaml
@@ -229,6 +229,9 @@ plugins:
       memoryRequest: 20Mi
       cpuLimit: 800m
       cpuRequest: 30m
+      volumeMounts:
+        - name: kube
+          path: /home/theia/.kube
     extension: https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/va21efef/vscode-openshift-connector-v0.2.11.vsix
     metaYaml:
       extraDependencies:


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds volume of `/home/theia/.kube` into the container where OS connector plugin is running

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2556

<!-- #### Changelog -->
N/A


#### Release Notes
N/A


#### Docs PR (if applicable)
N/A