### PR TITLE
feat(devfile): Add a link to devfile v2 for microprofile-xp3 sample

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/00_java11-maven-microprofile-xp3/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java11-maven-microprofile-xp3/meta.yaml
@@ -3,3 +3,5 @@ displayName: Java with JBoss EAP XP 3.0 Microprofile
 description: Java stack with OpenJDK 11, Maven 3.6.2 and JBoss EAP XP 3.0
 tags: ["Java", "OpenJDK", "Maven", "EAP", "Microprofile", "EAP XP", "RHEL8"]
 icon: /images/type-jboss.svg
+links:
+  v2: https://github.com/crw-samples/microprofile-quickstart/tree/devfilev2


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds a link to devfile version 2 for microprofile-xp3 sample. 
New devfile uses **mergeImage** sidecar-policy attribute, because we need `registry.redhat.io/jboss-eap-7/eap-xp3-openjdk11-openshift-rhel8` image to run WildFly server and `registry.redhat.io/codeready-workspaces/plugin-java11-rhel8` to run vscode-java plugin without problems.

The link to the devfile: https://github.com/crw-samples/microprofile-quickstart/blob/devfilev2/devfile.yaml

![screenshot-codeready-openshift-workspaces apps cluster-93f6 93f6 sandbox925 opentlc com-2021 12 16-13_11_24](https://user-images.githubusercontent.com/1271546/146365742-4a2a666f-b893-44d0-a6a2-80b5bc67da77.png)

![c2](https://user-images.githubusercontent.com/1271546/146365713-9fed2a99-24c5-4b1d-95d5-f1a606f5ba6f.png)

![screenshot-codeready-openshift-workspaces apps cluster-93f6 93f6 sandbox925 opentlc com-2021 12 16-13_35_24](https://user-images.githubusercontent.com/1271546/146365765-ad3974f2-8e85-464e-ab1d-a7846983cfa6.png)


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2412