### PR TITLE
feat(devfile): add link to devfile v2 for java8-maven-eap

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/00_java8-maven-eap/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java8-maven-eap/meta.yaml
@@ -3,3 +3,5 @@ displayName: Java with JBoss EAP 7.4
 description: Java stack with OpenJDK 8, Maven 3.6 and JBoss EAP 7.4
 tags: ["Java", "OpenJDK", "Maven", "EAP", "RHEL7"]
 icon: /images/type-jboss.svg
+links:
+  v2: https://github.com/crw-samples/jboss-eap-quickstarts/tree/devfilev2


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds a link to devfile v2 in java8-maven-eap

![1](https://user-images.githubusercontent.com/1271546/147289526-e3e02914-e340-4f30-9834-9482d1af15b4.png)

![2](https://user-images.githubusercontent.com/1271546/147289542-415b935b-5c2a-497b-ba1b-d12cd2e44440.png)

The link to the devfile: https://github.com/crw-samples/jboss-eap-quickstarts/tree/devfilev2

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2539

