### PR TITLE
feat(devfile): Add link to devfile v2 for dotnet stack

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/05_dotnet/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/05_dotnet/meta.yaml
@@ -3,3 +3,5 @@ displayName: ".NET"
 description: .NET stack with .NET Core SDK 3.1.103, Runtime, C# Language Support and Debugger
 tags: ["Tech-Preview", ".NET", "C#", ".NET SDK", ".NET Runtime", "Netcoredbg", "Omnisharp", "UBI8"]
 icon: /images/type-dotnet.svg
+links:
+  v2: https://github.com/crw-samples/dotnet-web-simple/tree/devfilev2


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds link to devfile version 2 for dotnet stack. 

![dotnet2](https://user-images.githubusercontent.com/1271546/149790750-c74988f5-809f-4e95-8f28-3bf7b1300bbb.png)

omnisharp and netcoredbg plugins have an issue with the initialization, it should be fixed by https://issues.redhat.com/browse/CRW-2456


Link to the devfile: https://github.com/crw-samples/dotnet-web-simple/blob/devfilev2/devfile.yaml

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2539
