### PR TITLE
feat(devfile):introduce devfile v 2 for nodejs-configmap sample

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/04_nodejs-configmap/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/04_nodejs-configmap/meta.yaml
@@ -3,3 +3,5 @@ displayName: NodeJS ConfigMap Express
 description: NodeJS stack with NPM 6.14.6, NodeJS 12.18.4 and ConfigMap Web Application 
 tags: ["NodeJS", "NPM", "Express", "UBI8"]
 icon: /images/type-node.svg
+links:
+  v2: https://github.com/crw-samples/nodejs-configmap/tree/devfilev2


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Adds link to devfile version 2 for nodejs-configmap sample. 

![screenshot-nimbus-capture-2022 01 19-13_10_40](https://user-images.githubusercontent.com/1271546/150123423-4f8ad5cc-e108-41b0-b195-9bdf540301ec.png)

Link to the devfile: https://github.com/crw-samples/nodejs-configmap/blob/devfilev2/devfile.yaml

Devfile contains `che-theia.eclipse.org/sidecar-policy: mergeImage` because for now we don't have one image with oc (needed for openshift-connector plugin) and npm (needed for typescript-language-features)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2539
