### PR TITLE
Fix 06_idea_rhel devfile to reference latest meta.yaml

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/06_idea_rhel/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/06_idea_rhel/devfile.yaml
@@ -5,4 +5,4 @@ metadata:
 components:
 -
   type: cheEditor
-  id: che-incubator/intellij-community/2020.3.3
+  id: che-incubator/intellij-community/latest


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Fix 06_idea_rhel devfile to reference latest meta.yaml

![Screenshot from 2022-01-28 12-24-03](https://user-images.githubusercontent.com/1197777/151530641-a9f9993b-36b7-4524-9f54-a539c302e548.png)

IntelliJ IDEA **meta.yaml** is placed into **v3/plugins/che-incubator/intellij-community/latest** directory in CRW 2.15.0.ER-01-27 plugin registry.

### What issues does this PR fix or reference?
Fixes https://issues.redhat.com/browse/CRW-2686

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
