### PR TITLE
CHORE: An update to copy all plugins and images

### DIFF
--- a/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-plugin-registry/build/dockerfiles/Dockerfile
@@ -47,8 +47,8 @@ RUN /tmp/rhel.install.sh && rm -f /tmp/rhel.install.sh
 COPY ./build/scripts/*.sh /build/
 COPY che-*.yaml /build/
 COPY resources.tgz /build/
-COPY ./v3/plugins/.htaccess /build/v3/plugins/.htaccess
-COPY ./v3/images/default.png /build/v3/images/
+COPY ./v3/plugins/ /build/v3/plugins/
+COPY ./v3/images/*.png /build/v3/images/
 WORKDIR /build/
 
 RUN tar -xvf resources.tgz -C ./
@@ -95,8 +95,8 @@ WORKDIR /var/www/html
 RUN mkdir -m 777 /var/www/html/v3
 COPY README.md .htaccess /var/www/html/
 COPY --from=builder /build/output/v3 /var/www/html/v3
-COPY --from=builder /build/v3/plugins/.htaccess /var/www/html/v3/plugins/
-COPY --from=builder /build/v3/images/default.png /var/www/html/v3/images/
+COPY --from=builder /build/v3/plugins/ /var/www/html/v3/plugins/
+COPY --from=builder /build/v3/images/ /var/www/html/v3/images/
 COPY ./build/dockerfiles/rhel.entrypoint.sh ./build/dockerfiles/entrypoint.sh /usr/local/bin/
 RUN chmod g+rwX /usr/local/bin/entrypoint.sh /usr/local/bin/rhel.entrypoint.sh && \
     chgrp -R 0 /var/www/html && chmod -R g+rw /var/www/html


### PR DESCRIPTION
This will aide in downstream projects to consume much easier and include their own plugins.

@nickboldt please review.
Upstream contribution
https://github.com/eclipse-che/che-plugin-registry/pull/1190

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Updates Dockerfile to copy multiple plugins and images.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
N/A
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
N/A
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
