### PR TITLE
fix: Move devfile templates generation to build.sh

### DIFF
--- a/dependencies/che-devfile-registry/build.sh
+++ b/dependencies/che-devfile-registry/build.sh
@@ -76,6 +76,19 @@ function parse_arguments() {
 
 parse_arguments "$@"
 
+function clear_generated_data() {
+    rm -rf ./resources
+    for dir in ./devfiles/*/
+    do
+      FILE="${dir}/devworkspace-che-theia-latest.yaml"
+      if [[ -f "$FILE" ]]; then
+        rm "${FILE}"
+      fi
+    done
+}
+
+./build/scripts/generate_devworkspace_templates.sh
+
 BUILD_COMMAND="build"
 if [[ -z $BUILDER ]]; then
     echo "BUILDER not specified, trying with podman"
@@ -108,7 +121,8 @@ else
 fi
 
 IMAGE="${REGISTRY}/${ORGANIZATION}/${CONTAINERNAME}:${TAG}"
-${BUILDER} ${BUILD_COMMAND} --build-arg VERSION="$(cat ../VERSION)"\
+${BUILDER} ${BUILD_COMMAND} \
     -t "${IMAGE}" \
     -f ${DOCKERFILE} \
     --target "${TARGET}" .
+clear_generated_data

--- a/dependencies/che-devfile-registry/build/dockerfiles/Dockerfile
+++ b/dependencies/che-devfile-registry/build/dockerfiles/Dockerfile
@@ -23,9 +23,6 @@ USER 0
 ARG BOOTSTRAP=false
 ENV BOOTSTRAP=${BOOTSTRAP}
 
-ARG VERSION=next
-ENV VERSION=${VERSION}
-
 # to get all the python deps pre-fetched so we can build in Brew:
 # 1. extract files in the container to your local filesystem
 #    find v3 -type f -exec dos2unix {} \;
@@ -54,6 +51,7 @@ RUN /tmp/rhel.install.sh && rm -f /tmp/rhel.install.sh
 COPY ./build/scripts ./arbitrary-users-patch/base_images /build/
 COPY ./versions.json /build/
 COPY ./devfiles /build/devfiles
+COPY ./resources /build/resources
 WORKDIR /build/
 
 # Registry, organization, and tag to use for base images in dockerfiles. Devfiles
@@ -69,7 +67,6 @@ RUN ./check_mandatory_fields.sh devfiles
 RUN ./swap_images.sh devfiles
 RUN ./index.sh > /build/devfiles/index.json
 RUN ./list_referenced_images.sh devfiles > /build/devfiles/external_images.txt
-RUN ./generate_devworkspace_templates.sh
 RUN chmod -R g+rwX /build/devfiles
 RUN chmod -R g+rwX /build/resources
 

--- a/dependencies/che-devfile-registry/build/scripts/generate_devworkspace_templates.sh
+++ b/dependencies/che-devfile-registry/build/scripts/generate_devworkspace_templates.sh
@@ -11,16 +11,17 @@
 set -e
 
 # shellcheck disable=SC1091
-source ./clone_and_zip.sh
+source ./build/scripts/clone_and_zip.sh
+VERSION=$(cat ../VERSION)
 arch="$(uname -m)"
 lib_name="che-theia-devworkspace-handler"
 npm install -g @eclipse-che/"${lib_name}"@"$(jq -r --arg v $lib_name '.[$v]' versions.json)"
-mkdir -p /build/resources/v2/
-for dir in /build/devfiles/*/
+mkdir -p ./resources/v2/
+for dir in ./devfiles/*/
 do
-  devfile_url=$(grep "\"v2\":" "${dir}"meta.yaml) || :
+  devfile_url=$(grep "v2:" "${dir}"meta.yaml) || :
   if [ -n "$devfile_url" ]; then
-    devfile_url=${devfile_url##*\"v2\": \"}
+    devfile_url=${devfile_url##*v2: }
     devfile_url=${devfile_url%/}
     devfile_url=${devfile_url%\"*}
     devfile_repo=${devfile_url%/tree*}
@@ -31,6 +32,6 @@ do
     --plugin-registry-url:https://redhat-developer.github.io/codeready-workspaces/che-plugin-registry/"${VERSION}"/"${arch}"/v3 \
     --output-file:"${dir}"devworkspace-che-theia-latest.yaml \
     "--project.${name}={{ DEVFILE_REGISTRY_URL }}/resources/v2/${name}.zip"
-    clone_and_zip "${devfile_repo}" "${devfile_url##*/}" "/build/resources/v2/$name.zip"
+    clone_and_zip "${devfile_repo}" "${devfile_url##*/}" "$(pwd)/resources/v2/$name.zip"
   fi
 done


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
In order to fix the Jenkins build, move the devfile v2 templates generation script to `./build.sh`

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2500

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
