### PR TITLE
chore: Include devfile v2 templates to swap_images list

### DIFF
--- a/dependencies/che-devfile-registry/build/scripts/list_yaml.sh
+++ b/dependencies/che-devfile-registry/build/scripts/list_yaml.sh
@@ -3,4 +3,4 @@
 # which is available at https://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
-find "$1" -name devfile.yaml
+find "$1" -name devfile.yaml -o -name devworkspace-che-theia-latest.yaml


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Expand the `list_yaml.sh` script, which generate a list of files for the `swap_images.sh` script, with devfile v2 templates to support images for different architectures. 

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2578
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
