### PR TITLE
chore: use crw-samples org for quarkus sample

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/03_java11-maven-quarkus/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/03_java11-maven-quarkus/devfile.yaml
@@ -6,7 +6,7 @@ projects:
   -
     name: quarkus-quickstarts
     source:
-      location: "https://github.com/quarkusio/quarkus-quickstarts.git"
+      location: "https://github.com/crw-samples/quarkus-quickstarts"
       branch: "main"
       type: git
       sparseCheckoutDir: "getting-started"


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Use [crw-samples](https://github.com/crw-samples) org to clone quarkus sample

![screenshot-codeready-crw-crwctl-gitlab apps ocp49 crw-qe com-2022 02 08-11_16_03](https://user-images.githubusercontent.com/1271546/152955788-6ac34390-ae61-426e-85df-cc234e3e5430.png)

### What issues does this PR fix or reference?
The latest version of Quarkus is required maven [3.8.1) but **plugin-java11-rhel8** image provides 3.6.3 
![Screenshot_20220208_085854](https://user-images.githubusercontent.com/1271546/152956056-aed22f0b-8eaa-47b8-bc1b-3953dad593c5.png)

We can update Maven in UDI for the next releases

Fixes https://issues.redhat.com/browse/CRW-2732