### PR TITLE
chore: remove redundant MAVEN_OPTS from build command

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/02_java8-maven-fuse/devfile.yaml
+++ b/dependencies/che-devfile-registry/devfiles/02_java8-maven-fuse/devfile.yaml
@@ -51,7 +51,7 @@ commands:
       -
         type: exec
         component: maven
-        command: "MAVEN_OPTS='-Xmx200m' && mvn clean package"
+        command: "mvn clean package"
         workdir: "${CHE_PROJECTS_ROOT}/java-fuse"
   -
     name: 2. Run


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Removes redundant MAVEN_OPTS from the 1. Build command to avoid overriding  
![screenshot-codeready-openshift-operators apps cluster-7568 7568 sandbox1862 opentlc com-2022 02 15-14_15_32](https://user-images.githubusercontent.com/1271546/154070531-621b2a83-6e71-4ba6-a45d-60923f383fe7.png)


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2752
