### PR TITLE
feat(devfile): update link to microprofile-bootable devfile v2

### DIFF
--- a/dependencies/che-devfile-registry/devfiles/00_java11-maven-microprofile-bootable/meta.yaml
+++ b/dependencies/che-devfile-registry/devfiles/00_java11-maven-microprofile-bootable/meta.yaml
@@ -4,4 +4,4 @@ description: Java stack with OpenJDK 11, Maven 3.6.3 and JBoss EAP XP 3.0 Bootab
 tags: ["Java", "OpenJDK", "Maven", "EAP", "Microprofile", "EAP XP", "Bootable Jar", "UBI8"]
 icon: /images/type-jboss.svg
 links:
-  v2: https://github.com/crw-samples/microprofile-quickstart/tree/devfilev2-bootable
+  v2: https://github.com/crw-samples/microprofile-quickstart-bootable/tree/devfilev2


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Changes the link to devfile v2 for microprofile-bootable sample. 
Now for microprofile-bootable devfile 2 we have own sample repo: https://github.com/crw-samples/microprofile-quickstart-bootable 

### What issues does this PR fix or reference?
Needs for https://issues.redhat.com/browse/CRW-2742