### PR TITLE
feat(prod): add script to create branches for crw-samples

### DIFF
--- a/product/tagRelease.sh
+++ b/product/tagRelease.sh
@@ -135,6 +135,19 @@ updateTechPreviewDevfiles() {
     git commit -a -s -m "chore(tech-preview-devfiles) update tag/branch to ${CRW_VERSION}"
 }
 
+# for the crw main repo, update meta.yaml files to point to the correct branch of crw-sample 
+updatelinksToDevfiles() {
+    YAML_ROOT="dependencies/che-devfile-registry/devfiles"
+
+    # replace CRW devfiles with image references to current version tag instead of crw-2-rhel-8 and :latest tag
+    for meta in $(find ${YAML_ROOT} -name "meta.yaml"); do
+       sed -r -i "${meta}" \
+           -e "s|devfilev2|${CRW_VERSION}-devfilev2/|g"
+    done
+    git diff -q "${YAML_ROOT}" || true
+    git commit -a -s -m "chore(devfile) update link to devfiles v2"
+}
+
 pushTagGH () {
 	d="$1"
 	org="$2"
@@ -165,7 +178,10 @@ pushTagGH () {
 		git branch ${branch} || true
 
 		# for the crw main repo, update tech preview devfiles to point to the correct tag/branch
-		if [[ $d == "codeready-workspaces" ]]; then updateTechPreviewDevfiles; fi
+		if [[ $d == "codeready-workspaces" ]]; then 
+			updateTechPreviewDevfiles;
+			updatelinksToDevfiles;
+		fi
 
 		git push origin ${branch} || true
 	fi

--- a/product/tagRelease.sh
+++ b/product/tagRelease.sh
@@ -136,13 +136,13 @@ updateTechPreviewDevfiles() {
 }
 
 # for the crw main repo, update meta.yaml files to point to the correct branch of crw-sample 
-updatelinksToDevfiles() {
+updateLinksToDevfiles() {
     YAML_ROOT="dependencies/che-devfile-registry/devfiles"
 
-    # replace CRW devfiles with image references to current version tag instead of crw-2-rhel-8 and :latest tag
+    # replace CRW meta.yaml files with links to current version of devfile v2
     for meta in $(find ${YAML_ROOT} -name "meta.yaml"); do
        sed -r -i "${meta}" \
-           -e "s|devfilev2|${CRW_VERSION}-devfilev2/|g"
+           -e "s|devfilev2|${CRW_VERSION}-devfilev2|g"
     done
     git diff -q "${YAML_ROOT}" || true
     git commit -a -s -m "chore(devfile) update link to devfiles v2"
@@ -172,7 +172,7 @@ pushTagGH () {
 		branch=${crw_repos_branch}
 		if [[ $org == "crw-samples" ]]; then 
 			# new branch for crw-sample should be 2.x-devfilev2
-			branch=$(echo "$crw_repos_branch" | cut -f2 -d'-')"-$SOURCE_BRANCH";
+			branch="$CRW_VERSION-$SOURCE_BRANCH";
 		fi
 		
 		git branch ${branch} || true
@@ -180,7 +180,7 @@ pushTagGH () {
 		# for the crw main repo, update tech preview devfiles to point to the correct tag/branch
 		if [[ $d == "codeready-workspaces" ]]; then 
 			updateTechPreviewDevfiles;
-			updatelinksToDevfiles;
+			updateLinksToDevfiles;
 		fi
 
 		git push origin ${branch} || true

--- a/product/tagRelease.sh
+++ b/product/tagRelease.sh
@@ -137,17 +137,18 @@ updateTechPreviewDevfiles() {
 
 pushTagGH () {
 	d="$1"
+	org="$2"
 	echo; echo "== $d =="
 	if [[ ${SOURCE_BRANCH} ]]; then clone_branch=${SOURCE_BRANCH}; else clone_branch=${crw_repos_branch}; fi
 	if [[ ! -d /tmp/tmp-checkouts/projects_${d} ]]; then
-		git clone --depth 1 -b ${clone_branch} https://github.com/redhat-developer/${d}.git projects_${d}
+		git clone --depth 1 -b ${clone_branch} https://github.com/${org}/${d}.git projects_${d}
 		pushd /tmp/tmp-checkouts/projects_${d} >/dev/null || exit 1
 			export GITHUB_TOKEN="${GITHUB_TOKEN}"
 			git config user.email "nickboldt+devstudio-release@gmail.com"
 			git config user.name "Red Hat Devstudio Release Bot"
 			git config --global push.default matching
 			git config --global hub.protocol https
-			git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/redhat-developer/${d}.git
+			git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${org}/${d}.git
 
 			git checkout --track origin/${clone_branch} -q || true
 			git pull -q
@@ -155,12 +156,18 @@ pushTagGH () {
 	fi
 	pushd /tmp/tmp-checkouts/projects_${d} >/dev/null || exit 1
 	if [[ ${SOURCE_BRANCH} ]]; then # push a new branch (or no-op if exists)
-		git branch ${crw_repos_branch} || true
+		branch=${crw_repos_branch}
+		if [[ $org == "crw-samples" ]]; then 
+			# new branch for crw-sample should be 2.x-devfilev2
+			branch=$(echo "$crw_repos_branch" | cut -f2 -d'-')"-$SOURCE_BRANCH";
+		fi
+		
+		git branch ${branch} || true
 
 		# for the crw main repo, update tech preview devfiles to point to the correct tag/branch
 		if [[ $d == "codeready-workspaces" ]]; then updateTechPreviewDevfiles; fi
 
-		git push origin ${crw_repos_branch} || true
+		git push origin ${branch} || true
 	fi
 	if [[ $CSV_VERSION ]]; then # push a new tag (or no-op if exists)
 		git tag ${CSV_VERSION} || true
@@ -169,13 +176,45 @@ pushTagGH () {
 	popd >/dev/null || exit 1
 }
 
+org="redhat-developer"
 for d in \
 codeready-workspaces \
 codeready-workspaces-chectl \
 codeready-workspaces-images \
 codeready-workspaces-theia \
 ; do
-	pushTagGH $d
+	pushTagGH $d $org
+done
+
+# create branches for crw samples
+# all samples are located in https://github.com/orgs/crw-samples
+# the source branch is devfilev2
+org="crw-samples"
+SOURCE_BRANCH="devfilev2"
+for s in \
+jboss-eap-quickstarts \
+microprofile-quickstart-bootable \
+microprofile-quickstart \
+fuse-rest-http-booster \
+camel-k \
+rest-http-example \
+gs-validating-form-input \
+lombok-project-sample \
+quarkus-quickstarts \
+vertx-health-checks-example-redhat \
+vertx-http-example \
+nodejs-configmap \
+nodejs-mongodb-sample \
+web-nodejs-sample \
+python-hello-world \
+c-plus-plus \
+dotnet-web-simple \
+golang-health-check \
+cakephp-ex \
+demo \
+gradle-demo-project \
+; do
+	pushTagGH $s $org
 done
 
 # cleanup


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Add logic to create branches of CRW samples. 
If the script will be executed in **crw-2.16-rhel-8** branch, in crw samples we should have **2.16-devfilev2** branches


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2742
